### PR TITLE
Sprint 6 -> staging (intermediate merge branch) (#125)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-polyfill": "^6.26.0",
     "body-parser": "^1.18.2",
     "bunyan": "^1.8.12",
+    "css-box-shadow": "^1.0.0-3",
     "date-fns": "^1.29.0",
     "draft-js": "^0.10.4",
     "draft-js-plugins-editor": "^2.0.4",

--- a/src/Components/AccountDropdown/AccountDropdown.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.jsx
@@ -11,6 +11,7 @@ export class AccountDropdown extends Component {
   constructor(props) {
     super(props);
     this.hideDropdown = this.hideDropdown.bind(this);
+    this.showDropdown = this.showDropdown.bind(this);
     this.logout = this.logout.bind(this);
   }
 
@@ -21,6 +22,11 @@ export class AccountDropdown extends Component {
   hideDropdown() {
     // Explicitly hide the dropdown using the built-in hide() function from react-simple-dropdown
     this.dropdown.hide();
+  }
+
+  showDropdown() {
+    // Explicitly show the dropdown using the built-in hide() function from react-simple-dropdown
+    this.dropdown.show();
   }
 
   render() {
@@ -42,8 +48,8 @@ export class AccountDropdown extends Component {
         className="account-dropdown"
         ref={(dropdown) => { this.dropdown = dropdown; }}
         removeElement
-        onMouseEnter={() => this.dropdown.show()}
-        onMouseLeave={() => this.dropdown.hide()}
+        onMouseEnter={this.showDropdown}
+        onMouseLeave={this.hideDropdown}
       >
         <DropdownTrigger href="/#">
           <Avatar className="account-dropdown--avatar" {...avatar} />
@@ -53,7 +59,7 @@ export class AccountDropdown extends Component {
           }
         </DropdownTrigger>
         <div className="dropdown-content-outer-container">
-          <DropdownContent onMouseEnter={() => this.dropdown.show()}>
+          <DropdownContent onMouseEnter={this.showDropdown}>
             <div className="account-dropdown--identity account-dropdown--segment">
               <div>Signed in as</div>
               <strong>{displayName}</strong>

--- a/src/Components/AccountDropdown/AccountDropdown.test.jsx
+++ b/src/Components/AccountDropdown/AccountDropdown.test.jsx
@@ -54,10 +54,24 @@ describe('AccountDropdown', () => {
     // define the instance
     const instance = accountDropdown.instance();
     instance.dropdown = { hide: () => {} };
-    // spy the logout function
+    // spy the hideDropdown function
     const spy = sinon.spy(instance, 'hideDropdown');
-    // click to logout
+    // call function
     instance.hideDropdown();
+    // logout function should have been called once
+    sinon.assert.calledOnce(spy);
+  });
+
+  it('can call the showDropdown function', () => {
+    const accountDropdown = shallow(<AccountDropdown />);
+
+    // define the instance
+    const instance = accountDropdown.instance();
+    instance.dropdown = { show: () => {} };
+    // spy the showDropdown function
+    const spy = sinon.spy(instance, 'showDropdown');
+    // click to logout
+    instance.showDropdown();
     // logout function should have been called once
     sinon.assert.calledOnce(spy);
   });

--- a/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
+++ b/src/Components/BidTracker/BidTrackerCard/BidTrackerCard.jsx
@@ -5,6 +5,7 @@ import BidSteps from '../BidStep';
 import BidTrackerCardBottom from '../BidTrackerCardBottom';
 import BidTrackerCardTop from '../BidTrackerCardTop';
 import OverlayAlert from '../OverlayAlert';
+import BoxShadow from '../../BoxShadow';
 import { shouldShowAlert } from '../BidHelpers';
 import {
   APPROVED_PROP,
@@ -24,7 +25,7 @@ userProfile }) => {
   // add class to container for draft since we need to apply an overflow:hidden for drafts only
   const draftClass = bid.status === DRAFT_PROP ? 'bid-tracker-bid-steps-container--draft' : '';
   return (
-    <div className="bid-tracker">
+    <BoxShadow className="bid-tracker">
       <div>
         <BidTrackerCardTop
           bid={bid}
@@ -57,7 +58,7 @@ userProfile }) => {
             </div>
           </div>
       }
-    </div>
+    </BoxShadow>
   );
 };
 

--- a/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCard/__snapshots__/BidTrackerCard.test.jsx.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BidTrackerCardComponent matches snapshot 1`] = `
-<div
+<BoxShadow
+  blurRadius={10}
   className="bid-tracker"
+  color="rgba(0,0,0,.15)"
+  inset={false}
+  is="div"
+  offsetX={3}
+  offsetY={2}
+  spreadRadius={1}
+  style={Object {}}
 >
   <div>
     <BidTrackerCardTop
@@ -56,6 +64,7 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
         }
       }
       deleteBid={[Function]}
+      hideDelete={false}
       showBidCount={true}
       showQuestion={true}
     />
@@ -170,5 +179,5 @@ exports[`BidTrackerCardComponent matches snapshot 1`] = `
       />
     </div>
   </div>
-</div>
+</BoxShadow>
 `;

--- a/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
+++ b/src/Components/BidTracker/BidTrackerCardTop/BidTrackerCardTop.jsx
@@ -21,7 +21,7 @@ class BidTrackerCardTop extends Component {
   }
 
   render() {
-    const { bid, showBidCount, showQuestion } = this.props;
+    const { bid, hideDelete, showBidCount, showQuestion } = this.props;
     const bidStatistics = get(bid, 'position.bid_statistics[0]', {});
     const post = get(bid, 'position.post', {});
     return (
@@ -45,7 +45,7 @@ class BidTrackerCardTop extends Component {
                 </div>
             }
             <div className="bid-tracker-actions-container">
-              { bid.can_delete &&
+              { bid.can_delete && !hideDelete &&
                 <ConfirmLink
                   className="remove-bid-link"
                   defaultText="Remove Bid"
@@ -66,11 +66,13 @@ BidTrackerCardTop.propTypes = {
   showQuestion: PropTypes.bool, // Determine whether or not to show the question text
   deleteBid: PropTypes.func.isRequired,
   showBidCount: PropTypes.bool,
+  hideDelete: PropTypes.bool,
 };
 
 BidTrackerCardTop.defaultProps = {
   showQuestion: true,
   showBidCount: true,
+  hideDelete: false,
 };
 
 export default BidTrackerCardTop;

--- a/src/Components/BidTracker/PriorityCards/IsOnStandby/IsOnStandby.jsx
+++ b/src/Components/BidTracker/PriorityCards/IsOnStandby/IsOnStandby.jsx
@@ -31,6 +31,7 @@ const IsOnStandby = ({ bid, deleteBid }) => {
           showQuestion={false}
           bid={bid}
           deleteBid={deleteBid}
+          hideDelete
         />
       </div>
     </div>

--- a/src/Components/BidTracker/PriorityCards/IsOnStandby/__snapshots__/IsOnStandby.test.jsx.snap
+++ b/src/Components/BidTracker/PriorityCards/IsOnStandby/__snapshots__/IsOnStandby.test.jsx.snap
@@ -77,6 +77,7 @@ exports[`IsOnStandbyComponent matches snapshot 1`] = `
         }
       }
       deleteBid={[Function]}
+      hideDelete={true}
       showBidCount={false}
       showQuestion={false}
     />

--- a/src/Components/BidTracker/PriorityCards/IsPriority/IsPriority.jsx
+++ b/src/Components/BidTracker/PriorityCards/IsPriority/IsPriority.jsx
@@ -7,11 +7,11 @@ const IsPriority = ({ children }) => (
     <div className="usa-grid-full bid-tracker-priority-wrapper">
       <div className="usa-grid-full padded-container-inner priority-banner">
         <div className="usa-width-one-half priority-banner-container-left">
-          Priority Assignment
+          Pending Assignment
         </div>
         <div className="usa-width-one-half priority-banner-container-right">
           <div className="priority-banner-question-text">
-            <FontAwesome name="question-circle" /> What is a priority Assignment?
+            <FontAwesome name="question-circle" /> What is a Pending Assignment?
           </div>
         </div>
       </div>

--- a/src/Components/BidTracker/PriorityCards/IsPriority/__snapshots__/IsPriority.test.jsx.snap
+++ b/src/Components/BidTracker/PriorityCards/IsPriority/__snapshots__/IsPriority.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IsPriorityComponent matches snapshot 1`] = `
+exports['IsPriorityComponent matches snapshot 1'] = `
 <div
   className="usa-grid-full bid-tracker-priority-wrapper-container"
 >
@@ -13,7 +13,7 @@ exports[`IsPriorityComponent matches snapshot 1`] = `
       <div
         className="usa-width-one-half priority-banner-container-left"
       >
-        Priority Assignment
+        Pending Assignment
       </div>
       <div
         className="usa-width-one-half priority-banner-container-right"
@@ -24,7 +24,7 @@ exports[`IsPriorityComponent matches snapshot 1`] = `
           <FontAwesome
             name="question-circle"
           />
-           What is a priority Assignment?
+           What is a Pending Assignment?
         </div>
       </div>
     </div>

--- a/src/Components/BidderPortfolio/BidderPortfolioCard/BidderPortfolioCard.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioCard/BidderPortfolioCard.jsx
@@ -4,9 +4,10 @@ import UserProfileGeneralInformation from '../../ProfileDashboard/UserProfile/Us
 import UserProfilePersonalInformation from '../../ProfileDashboard/UserProfile/UserProfilePersonalInformation';
 import UserProfileBidInformation from '../../ProfileDashboard/UserProfile/UserProfileBidInformation';
 import BidderPortfolioViewMore from '../BidderPortfolioViewMore';
+import BoxShadow from '../../BoxShadow';
 
 const BidderPortfolioCard = ({ userProfile }) => (
-  <div className="usa-grid-full current-user bidder-portfolio-card">
+  <BoxShadow className="usa-grid-full current-user bidder-portfolio-card">
     <UserProfileGeneralInformation
       userProfile={userProfile}
       showEditLink={false}
@@ -19,7 +20,7 @@ const BidderPortfolioCard = ({ userProfile }) => (
       submitted={userProfile.bid_statistics[0] ? userProfile.bid_statistics[0].submitted : 0}
     />
     <BidderPortfolioViewMore useLink id={userProfile.id} />
-  </div>
+  </BoxShadow>
 );
 
 BidderPortfolioCard.propTypes = {

--- a/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
-<div
+<BoxShadow
+  blurRadius={10}
   className="usa-grid-full current-user bidder-portfolio-card"
+  color="rgba(0,0,0,.15)"
+  inset={false}
+  is="div"
+  offsetX={3}
+  offsetY={2}
+  spreadRadius={1}
+  style={Object {}}
 >
   <UserProfileGeneralInformation
     showEditLink={false}
@@ -128,5 +136,5 @@ exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
     onClick={[Function]}
     useLink={true}
   />
-</div>
+</BoxShadow>
 `;

--- a/src/Components/BoxShadow/BoxShadow.jsx
+++ b/src/Components/BoxShadow/BoxShadow.jsx
@@ -1,0 +1,47 @@
+// forked from https://github.com/lachlanjc/react-box-shadow
+import React from 'react';
+import PropTypes from 'prop-types';
+import cssShadow from 'css-box-shadow';
+
+const BoxShadow = ({ is, inset, offsetX, offsetY, blurRadius, spreadRadius, color, style,
+...props }) => {
+  const Component = is;
+  const sx = {
+    ...style,
+    boxShadow: cssShadow.stringify([
+      {
+        inset,
+        offsetX,
+        offsetY,
+        blurRadius,
+        spreadRadius,
+        color,
+      },
+    ]),
+  };
+  return <Component style={sx} {...props} />;
+};
+
+BoxShadow.propTypes = {
+  is: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  inset: PropTypes.bool,
+  offsetX: PropTypes.number,
+  offsetY: PropTypes.number,
+  blurRadius: PropTypes.number,
+  spreadRadius: PropTypes.number,
+  color: PropTypes.string,
+  style: PropTypes.shape({}),
+};
+
+BoxShadow.defaultProps = {
+  is: 'div',
+  inset: false,
+  offsetX: 3,
+  offsetY: 2,
+  blurRadius: 10,
+  spreadRadius: 1,
+  color: 'rgba(0,0,0,.15)',
+  style: {},
+};
+
+export default BoxShadow;

--- a/src/Components/BoxShadow/BoxShadow.test.jsx
+++ b/src/Components/BoxShadow/BoxShadow.test.jsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import BoxShadow from './BoxShadow';
+
+describe('BoxShadow', () => {
+  it('can receive props', () => {
+    const wrapper = shallow(
+      <BoxShadow
+        is="span"
+        inset
+        offsetX={23}
+        offsetY={25}
+        blurRadius={27}
+        spreadRadius={29}
+        color="#f2f2f2"
+        style={{ backgroundColor: 'red' }}
+      />,
+    );
+    const output = {
+      backgroundColor: 'red',
+      boxShadow: 'inset 23px 25px 27px 29px #f2f2f2',
+    };
+    expect(wrapper.props().style).toEqual(output);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <BoxShadow />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/BoxShadow/__snapshots__/BoxShadow.test.jsx.snap
+++ b/src/Components/BoxShadow/__snapshots__/BoxShadow.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BoxShadow matches snapshot 1`] = `
+<div
+  style={
+    Object {
+      "boxShadow": "3px 2px 10px 1px rgba(0,0,0,.15)",
+    }
+  }
+/>
+`;

--- a/src/Components/BoxShadow/index.js
+++ b/src/Components/BoxShadow/index.js
@@ -1,0 +1,1 @@
+export { default } from './BoxShadow';

--- a/src/Components/CompareDrawer/CompareDrawerContainer.jsx
+++ b/src/Components/CompareDrawer/CompareDrawerContainer.jsx
@@ -7,7 +7,7 @@ import CompareDrawer from './CompareDrawer';
 import { COMPARE_LIST } from '../../Constants/PropTypes';
 import { getScrollDistanceFromBottom } from '../../utilities';
 
-class Compare extends Component {
+export class Compare extends Component {
   constructor(props) {
     super(props);
     this.lsListener = this.lsListener.bind(this);

--- a/src/Components/CompareDrawer/CompareDrawerContainer.test.jsx
+++ b/src/Components/CompareDrawer/CompareDrawerContainer.test.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { testDispatchFunctions } from '../../testUtilities/testUtilities';
-import CompareDrawerContainer, { mapDispatchToProps } from './CompareDrawerContainer';
+import CompareDrawerContainer, { Compare, mapDispatchToProps } from './CompareDrawerContainer';
 import resultsObject from '../../__mocks__/resultsObject';
 
 const middlewares = [thunk];
@@ -13,13 +14,36 @@ const mockStore = configureStore(middlewares);
 
 describe('CompareDrawerContainer', () => {
   it('is defined', () => {
-    const compare = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
+    const wrapper = TestUtils.renderIntoDocument(<Provider store={mockStore({})}><MemoryRouter>
       <CompareDrawerContainer
         fetchData={() => {}}
         comparisons={resultsObject.results}
       />
     </MemoryRouter></Provider>);
-    expect(compare).toBeDefined();
+    expect(wrapper).toBeDefined();
+  });
+
+  it('returns correct values for shouldComponentUpdate', () => {
+    const props = {
+      fetchData: () => {},
+      comparisons: resultsObject.results,
+      hasErrored: false,
+    };
+    const wrapper = shallow(
+      <Compare
+        {...props}
+      />,
+    );
+    // check that new props return true
+    const shouldReturnTrue = wrapper.instance().shouldComponentUpdate({}, {});
+    expect(shouldReturnTrue).toBe(true);
+    // check that new state values, excluding 'comparisons', returns true
+    const shouldAlsoReturnTrue = wrapper.instance().shouldComponentUpdate({}, { prevComparisons: ['fake'],
+      isHidden: true });
+    expect(shouldAlsoReturnTrue).toBe(true);
+    // if everything else is equal but 'comparisons' is new, should return false
+    const shouldReturnFalse = wrapper.instance().shouldComponentUpdate(props, { ...wrapper.instance().state, comparisons: ['new'] });
+    expect(shouldReturnFalse).toBe(false);
   });
 });
 

--- a/src/Components/CompareList/CompareList.jsx
+++ b/src/Components/CompareList/CompareList.jsx
@@ -124,6 +124,34 @@ onToggle }) => {
                     }
                   </tr>
                   <tr>
+                    <th scope="row">
+                      Post
+                    </th>
+                    {
+                      compareArray.map(c => (
+                        <td key={shortId.generate()}>
+                          {getPostName(c.post, NO_POST)}
+                        </td>
+                      ))
+                    }
+                    {
+                      emptyArray.map(() => <td className="empty" key={shortId.generate()} />)
+                    }
+                  </tr>
+                  <tr>
+                    <th scope="row">TED</th>
+                    {
+                      compareArray.map(c => (
+                        <td key={shortId.generate()}>
+                          {propOrDefault(c, 'current_assignment.estimated_end_date') ? formatDate(c.current_assignment.estimated_end_date) : NO_DATE }
+                        </td>
+                      ))
+                    }
+                    {
+                      emptyArray.map(() => <td className="empty" key={shortId.generate()} />)
+                    }
+                  </tr>
+                  <tr>
                     <th scope="row">Skill</th>
                     {
                       compareArray.map(c => (
@@ -139,21 +167,6 @@ onToggle }) => {
                     {
                       compareArray.map(c => (
                         <td key={shortId.generate()}>{c.bureau || NO_BUREAU}</td>
-                      ))
-                    }
-                    {
-                      emptyArray.map(() => <td className="empty" key={shortId.generate()} />)
-                    }
-                  </tr>
-                  <tr>
-                    <th scope="row">
-                      Post
-                    </th>
-                    {
-                      compareArray.map(c => (
-                        <td key={shortId.generate()}>
-                          {getPostName(c.post, NO_POST)}
-                        </td>
                       ))
                     }
                     {
@@ -209,19 +222,6 @@ onToggle }) => {
                         <td key={shortId.generate()}>
                           {getDifferentialPercentage(propOrDefault(c, 'post.danger_pay'), NO_DANGER_PAY)}
                           {propOrDefault(c, 'post.obc_id') ? <span> | <OBCUrl id={c.post.obc_id} label="View OBC Data" /></span> : null }
-                        </td>
-                      ))
-                    }
-                    {
-                      emptyArray.map(() => <td className="empty" key={shortId.generate()} />)
-                    }
-                  </tr>
-                  <tr>
-                    <th scope="row">TED</th>
-                    {
-                      compareArray.map(c => (
-                        <td key={shortId.generate()}>
-                          {propOrDefault(c, 'current_assignment.estimated_end_date') ? formatDate(c.current_assignment.estimated_end_date) : NO_DATE }
                         </td>
                       ))
                     }

--- a/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
+++ b/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
@@ -265,6 +265,50 @@ exports[`CompareListComponent matches snapshot 1`] = `
             <th
               scope="row"
             >
+              Post
+            </th>
+            <td>
+              Freetown, Sierra Leone
+            </td>
+            <td>
+              Chicago, IL
+            </td>
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              TED
+            </th>
+            <td>
+              None listed
+            </td>
+            <td>
+              03/13/2020
+            </td>
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
               Skill
             </th>
             <td>
@@ -294,28 +338,6 @@ exports[`CompareListComponent matches snapshot 1`] = `
             </td>
             <td>
               (WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS
-            </td>
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-          </tr>
-          <tr>
-            <th
-              scope="row"
-            >
-              Post
-            </th>
-            <td>
-              Freetown, Sierra Leone
-            </td>
-            <td>
-              Chicago, IL
             </td>
             <td
               className="empty"
@@ -427,28 +449,6 @@ exports[`CompareListComponent matches snapshot 1`] = `
             </td>
             <td>
               15%
-            </td>
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-          </tr>
-          <tr>
-            <th
-              scope="row"
-            >
-              TED
-            </th>
-            <td>
-              None listed
-            </td>
-            <td>
-              03/13/2020
             </td>
             <td
               className="empty"
@@ -827,6 +827,50 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
             <th
               scope="row"
             >
+              Post
+            </th>
+            <td>
+              Freetown, Sierra Leone
+            </td>
+            <td>
+              Chicago, IL
+            </td>
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
+              TED
+            </th>
+            <td>
+              None listed
+            </td>
+            <td>
+              03/13/2020
+            </td>
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+            <td
+              className="empty"
+            />
+          </tr>
+          <tr>
+            <th
+              scope="row"
+            >
               Skill
             </th>
             <td>
@@ -856,28 +900,6 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
             </td>
             <td>
               (WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS
-            </td>
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-          </tr>
-          <tr>
-            <th
-              scope="row"
-            >
-              Post
-            </th>
-            <td>
-              Freetown, Sierra Leone
-            </td>
-            <td>
-              Chicago, IL
             </td>
             <td
               className="empty"
@@ -1009,28 +1031,6 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
             </td>
             <td>
               15%
-            </td>
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-            <td
-              className="empty"
-            />
-          </tr>
-          <tr>
-            <th
-              scope="row"
-            >
-              TED
-            </th>
-            <td>
-              None listed
-            </td>
-            <td>
-              03/13/2020
             </td>
             <td
               className="empty"

--- a/src/Components/CondensedCardData/CondensedCardData.jsx
+++ b/src/Components/CondensedCardData/CondensedCardData.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { POSITION_DETAILS } from '../../Constants/PropTypes';
-import { NO_DATE, NO_POST, NO_SKILL } from '../../Constants/SystemMessages';
+import { NO_DATE, NO_GRADE, NO_SKILL } from '../../Constants/SystemMessages';
 import LanguageList from '../LanguageList';
 import CondensedCardDataPoint from './CondensedCardDataPoint';
-import { formatDate, getPostName, propOrDefault } from '../../utilities';
+import { formatDate, propOrDefault } from '../../utilities';
 
 const CondensedCardData = ({ position }) => {
   const estimatedEndDate = propOrDefault(position, 'current_assignment.estimated_end_date') ?
@@ -11,18 +11,18 @@ const CondensedCardData = ({ position }) => {
   return (
     <div className="usa-grid-full condensed-card-data">
       <CondensedCardDataPoint
+        title="TED"
+        content={estimatedEndDate}
+        hasFixedTitleWidth
+      />
+      <CondensedCardDataPoint
         title="Skill"
         content={position.skill || NO_SKILL}
         hasFixedTitleWidth
       />
       <CondensedCardDataPoint
-        title="Post"
-        content={getPostName(position.post, NO_POST)}
-        hasFixedTitleWidth
-      />
-      <CondensedCardDataPoint
-        title="TED"
-        content={estimatedEndDate}
+        title="Grade"
+        content={position.grade || NO_GRADE}
         hasFixedTitleWidth
       />
       <CondensedCardDataPoint

--- a/src/Components/CondensedCardData/__snapshots__/CondensedCardData.test.jsx.snap
+++ b/src/Components/CondensedCardData/__snapshots__/CondensedCardData.test.jsx.snap
@@ -5,19 +5,19 @@ exports[`CondensedCardDataComponent matches snapshot 1`] = `
   className="usa-grid-full condensed-card-data"
 >
   <CondensedCardDataPoint
+    content="03/13/2020"
+    hasFixedTitleWidth={true}
+    title="TED"
+  />
+  <CondensedCardDataPoint
     content="OFFICE MANAGEMENT (9017)"
     hasFixedTitleWidth={true}
     title="Skill"
   />
   <CondensedCardDataPoint
-    content="Freetown, Sierra Leone"
+    content="06"
     hasFixedTitleWidth={true}
-    title="Post"
-  />
-  <CondensedCardDataPoint
-    content="03/13/2020"
-    hasFixedTitleWidth={true}
-    title="TED"
+    title="Grade"
   />
   <CondensedCardDataPoint
     content={
@@ -39,17 +39,17 @@ exports[`CondensedCardDataComponent matches snapshot with an empty estimated end
   <CondensedCardDataPoint
     content="None listed"
     hasFixedTitleWidth={true}
-    title="Skill"
-  />
-  <CondensedCardDataPoint
-    content="Freetown, Sierra Leone"
-    hasFixedTitleWidth={true}
-    title="Post"
+    title="TED"
   />
   <CondensedCardDataPoint
     content="None listed"
     hasFixedTitleWidth={true}
-    title="TED"
+    title="Skill"
+  />
+  <CondensedCardDataPoint
+    content="06"
+    hasFixedTitleWidth={true}
+    title="Grade"
   />
   <CondensedCardDataPoint
     content={
@@ -69,19 +69,19 @@ exports[`CondensedCardDataComponent matches snapshot with an empty skill 1`] = `
   className="usa-grid-full condensed-card-data"
 >
   <CondensedCardDataPoint
+    content="03/13/2020"
+    hasFixedTitleWidth={true}
+    title="TED"
+  />
+  <CondensedCardDataPoint
     content="None listed"
     hasFixedTitleWidth={true}
     title="Skill"
   />
   <CondensedCardDataPoint
-    content="Freetown, Sierra Leone"
+    content="06"
     hasFixedTitleWidth={true}
-    title="Post"
-  />
-  <CondensedCardDataPoint
-    content="03/13/2020"
-    hasFixedTitleWidth={true}
-    title="TED"
+    title="Grade"
   />
   <CondensedCardDataPoint
     content={

--- a/src/Components/EmptyListAlert/NoSavedSearches/NoSavedSearches.jsx
+++ b/src/Components/EmptyListAlert/NoSavedSearches/NoSavedSearches.jsx
@@ -3,7 +3,7 @@ import EmptyListAlert from '../EmptyListAlert';
 
 const NoSavedSearches = () => {
   const textLineTwo = `Reuse this job search in the future by clicking "Save this search".
-  Try naming your search something memorable, like "Summer Positions 2018".`;
+  Try naming your search something memorable, like "Summer Positions in My Grade".`;
   return (
     <EmptyListAlert
       textLineOne="You haven't saved any searches."

--- a/src/Components/EmptyListAlert/NoSavedSearches/__snapshots__/NoSavedSearches.test.jsx.snap
+++ b/src/Components/EmptyListAlert/NoSavedSearches/__snapshots__/NoSavedSearches.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`NoSavedSearchesComponent matches snapshot 1`] = `
   textLineTwo={
     <span>
       Reuse this job search in the future by clicking "Save this search".
-  Try naming your search something memorable, like "Summer Positions 2018".
+  Try naming your search something memorable, like "Summer Positions in My Grade".
     </span>
   }
 />

--- a/src/Components/Favorite/Favorite.jsx
+++ b/src/Components/Favorite/Favorite.jsx
@@ -67,7 +67,8 @@ class Favorite extends Component {
     }
 
     isUpdate = (oldState !== newState) ||
-               (this.state.loading !== nextState.isLoading);
+               (this.state.loading !== nextState.isLoading) ||
+               nextProps.hasErrored;
 
     return isUpdate;
   }
@@ -190,10 +191,11 @@ Favorite.propTypes = {
   className: PropTypes.string,
   as: PropTypes.string.isRequired,
   onToggle: PropTypes.func.isRequired,
-  refKey: PropTypes.node.isRequired,
+  refKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string.isRequired]).isRequired,
   hideText: PropTypes.bool,
   compareArray: FAVORITE_POSITIONS_ARRAY.isRequired,
   isLoading: PropTypes.bool,
+  hasErrored: PropTypes.bool,
   hasBorder: PropTypes.bool,
   useLongText: PropTypes.bool,
   useButtonClass: PropTypes.bool,
@@ -207,6 +209,7 @@ Favorite.defaultProps = {
   as: 'div',
   hideText: false,
   isLoading: false,
+  hasErrored: false,
   compareArray: [],
   hasBorder: false,
   useLongText: false,

--- a/src/Components/FavoriteMessages/Success.jsx
+++ b/src/Components/FavoriteMessages/Success.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { POSITION_DETAILS } from '../../Constants/PropTypes';
+
+const Success = ({ pos }) => (
+  <span>{pos.title} ({pos.position_number}) has been successfully added to Favorites. <Link to="/profile/favorites/">Go to Favorites</Link>.</span>
+);
+
+Success.propTypes = {
+  pos: POSITION_DETAILS.isRequired,
+};
+
+export default Success;

--- a/src/Components/FavoriteMessages/Success.test.jsx
+++ b/src/Components/FavoriteMessages/Success.test.jsx
@@ -1,0 +1,11 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Success from './Success';
+import detailsObject from '../../__mocks__/detailsObject';
+
+describe('Success', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<Success pos={detailsObject} />);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -40,6 +40,7 @@ bidList, onSortChange }) => (
       title="favorites"
       maxLength={300}
       refreshFavorites
+      showBidListButton
     />
   </div>
 );

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -559,6 +559,7 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
       ]
     }
     refreshFavorites={true}
+    showBidListButton={true}
     title="favorites"
     type="default"
   />

--- a/src/Components/GlossaryEditor/GlossaryEditorCard/GlossaryEditorCard.jsx
+++ b/src/Components/GlossaryEditor/GlossaryEditorCard/GlossaryEditorCard.jsx
@@ -4,6 +4,7 @@ import { GLOSSARY_OBJECT, EMPTY_FUNCTION, GLOSSARY_ERROR_OBJECT } from '../../..
 import TextEditor from '../../TextEditor';
 import InteractiveElement from '../../InteractiveElement';
 import GlossaryEditorCardBottom from '../GlossaryEditorCardBottom';
+import BoxShadow from '../../BoxShadow';
 import { isUrl } from '../../../utilities';
 
 const isEmpty = value => (value || '').length === 0;
@@ -175,7 +176,7 @@ class GlossaryEditorCard extends Component {
     } = this.editorClasses;
 
     return (
-      <div className={`usa-grid-full section-padded-inner-container glossary-editor-card ${editorContainerHiddenClass}`}>
+      <BoxShadow className={`usa-grid-full section-padded-inner-container glossary-editor-card ${editorContainerHiddenClass}`}>
         <div className="usa-grid-full glossary-editor-card-top">
           <div className={`title-container ${editorHiddenClass} ${titleContainerClass}`}>
             {
@@ -241,7 +242,7 @@ class GlossaryEditorCard extends Component {
           id={term.id || null}
           submitGlossaryTerm={submitGlossaryTerm}
         />
-      </div>
+      </BoxShadow>
     );
   }
 }

--- a/src/Components/GlossaryEditor/GlossaryEditorCard/__snapshots__/GlossaryEditorCard.test.jsx.snap
+++ b/src/Components/GlossaryEditor/GlossaryEditorCard/__snapshots__/GlossaryEditorCard.test.jsx.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GlossaryEditorCardComponent matches snapshot 1`] = `
-<div
+<BoxShadow
+  blurRadius={10}
   className="usa-grid-full section-padded-inner-container glossary-editor-card editor-container-hidden"
+  color="rgba(0,0,0,.15)"
+  inset={false}
+  is="div"
+  offsetX={3}
+  offsetY={2}
+  spreadRadius={1}
+  style={Object {}}
 >
   <div
     className="usa-grid-full glossary-editor-card-top"
@@ -60,12 +68,20 @@ exports[`GlossaryEditorCardComponent matches snapshot 1`] = `
     submitGlossaryTerm={[Function]}
     updatedBy="Leah Shadtrach"
   />
-</div>
+</BoxShadow>
 `;
 
 exports[`GlossaryEditorCardComponent matches snapshot when displayZeroLengthAlert is true 1`] = `
-<div
+<BoxShadow
+  blurRadius={10}
   className="usa-grid-full section-padded-inner-container glossary-editor-card editor-container-hidden"
+  color="rgba(0,0,0,.15)"
+  inset={false}
+  is="div"
+  offsetX={3}
+  offsetY={2}
+  spreadRadius={1}
+  style={Object {}}
 >
   <div
     className="usa-grid-full glossary-editor-card-top"
@@ -123,5 +139,5 @@ exports[`GlossaryEditorCardComponent matches snapshot when displayZeroLengthAler
     submitGlossaryTerm={[Function]}
     updatedBy="Leah Shadtrach"
   />
-</div>
+</BoxShadow>
 `;

--- a/src/Components/HomePagePositionsList/HomePagePositionsList.jsx
+++ b/src/Components/HomePagePositionsList/HomePagePositionsList.jsx
@@ -11,6 +11,7 @@ const propTypes = {
   type: HOME_PAGE_CARD_TYPE,
   refreshFavorites: PropTypes.bool,
   title: PropTypes.string.isRequired, // should be unique per page, since its used a react key
+  showBidListButton: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -19,10 +20,11 @@ const defaultProps = {
   isLoading: false,
   type: 'default',
   refreshFavorites: false,
+  showBidListButton: false,
 };
 
 const HomePagePositionsList = ({ positions, favorites, isLoading,
-    bidList, type, refreshFavorites, title }) => (
+    bidList, type, refreshFavorites, title, showBidListButton }) => (
       <div className={`condensed-card-highlighted ${isLoading ? 'results-loading' : ''}`}>
         <div className="usa-grid-full condensed-card-grid">
           {positions.map(p => (
@@ -33,6 +35,7 @@ const HomePagePositionsList = ({ positions, favorites, isLoading,
                 bidList={bidList}
                 type={type}
                 refreshFavorites={refreshFavorites}
+                showBidListButton={showBidListButton}
               />
             </div>
           ))}

--- a/src/Components/HomePagePositionsList/__snapshots__/HomePagePositionsList.test.jsx.snap
+++ b/src/Components/HomePagePositionsList/__snapshots__/HomePagePositionsList.test.jsx.snap
@@ -237,6 +237,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>
@@ -470,6 +471,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>
@@ -703,6 +705,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>
@@ -936,6 +939,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>
@@ -1169,6 +1173,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>
@@ -1402,6 +1407,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>
@@ -1635,6 +1641,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           }
         }
         refreshFavorites={false}
+        showBidListButton={false}
         type="default"
       />
     </div>

--- a/src/Components/HomePagePositionsSection/__snapshots__/HomePagePositionsSection.test.jsx.snap
+++ b/src/Components/HomePagePositionsSection/__snapshots__/HomePagePositionsSection.test.jsx.snap
@@ -343,6 +343,7 @@ exports[`HomePagePositionsSection matches snapshot 1`] = `
       ]
     }
     refreshFavorites={false}
+    showBidListButton={false}
     title="Title"
     type="default"
   />

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import CondensedCardDataPoint from '../CondensedCardData/CondensedCardDataPoint';
 import OBCUrl from '../OBCUrl';
 import PositionDetailsDescription from './PositionDetailsDescription';
 import PositionDetailsContact from './PositionDetailsContact';
 import ServiceNeededToggle from './ServiceNeededToggle';
+import Handshake from '../Ribbon/Handshake';
 import {
   formatDate,
   propOrDefault,
   getAccessiblePositionNumber,
   getDifferentialPercentage,
+  getBidStatisticsObject,
 } from '../../utilities';
 
 import { DEFAULT_HIGHLIGHT_POSITION } from '../../Constants/DefaultProps';
@@ -63,8 +66,15 @@ const PositionDetailsItem = (props) => {
   };
 
   const incumbent = propOrDefault(details, 'current_assignment.user', NO_USER_LISTED);
+
+  const stats = getBidStatisticsObject(details.bid_statistics);
   return (
-    <div className="usa-grid-full padded-main-content">
+    <div className="usa-grid-full padded-main-content position-details-outer-container">
+      <div className="handshake-offset-container">
+        {
+          get(stats, 'has_handshake_offered', false) && <Handshake cutSide="right" className="ribbon-position-details" />
+        }
+      </div>
       <div className="usa-grid-full position-details-description-container positions-details-about-position">
         <div className="usa-width-two-thirds about-section-left">
           <h2>About the Position</h2>

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -2,8 +2,11 @@
 
 exports[`PositionDetailsItem matches snapshot 1`] = `
 <div
-  className="usa-grid-full padded-main-content"
+  className="usa-grid-full padded-main-content position-details-outer-container"
 >
+  <div
+    className="handshake-offset-container"
+  />
   <div
     className="usa-grid-full position-details-description-container positions-details-about-position"
   >
@@ -193,8 +196,11 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
 
 exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
 <div
-  className="usa-grid-full padded-main-content"
+  className="usa-grid-full padded-main-content position-details-outer-container"
 >
+  <div
+    className="handshake-offset-container"
+  />
   <div
     className="usa-grid-full position-details-description-container positions-details-about-position"
   >
@@ -416,8 +422,11 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
 
 exports[`PositionDetailsItem matches snapshot when various data is missing from the position 1`] = `
 <div
-  className="usa-grid-full padded-main-content"
+  className="usa-grid-full padded-main-content position-details-outer-container"
 >
+  <div
+    className="handshake-offset-container"
+  />
   <div
     className="usa-grid-full position-details-description-container positions-details-about-position"
   >

--- a/src/Components/ProfileDashboard/ExternalUserStatus/ExternalUserStatus.jsx
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/ExternalUserStatus.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '../../Avatar';
-import Status from '../UserProfile/Status';
 import USER_TYPES from '../../../Constants/UserTypes';
 import MailToButton from '../../MailToButton';
 
@@ -10,9 +9,6 @@ const ExternalUserStatus = ({ initials, firstName, lastName, type, showMail, ema
     <div className="usa-grid-full cdo-container-inner section-padded-inner-container">
       <div className="profile-picture-container">
         <Avatar initials={initials} firstName={firstName} lastName={lastName} small />
-        <div className="picture-status-container">
-          <Status hideText />
-        </div>
       </div>
       <div className="cdo-text-container">
         <div className="usa-grid-full">

--- a/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
+++ b/src/Components/ProfileDashboard/ExternalUserStatus/__snapshots__/ExternalUserStatus.test.jsx.snap
@@ -18,13 +18,6 @@ exports[`ExternalUserStatusComponent matches snapshot 1`] = `
         onClick={[Function]}
         small={true}
       />
-      <div
-        className="picture-status-container"
-      >
-        <Status
-          hideText={true}
-        />
-      </div>
     </div>
     <div
       className="cdo-text-container"
@@ -70,13 +63,6 @@ exports[`ExternalUserStatusComponent matches snapshot when showMail is true 1`] 
         onClick={[Function]}
         small={true}
       />
-      <div
-        className="picture-status-container"
-      >
-        <Status
-          hideText={true}
-        />
-      </div>
     </div>
     <div
       className="cdo-text-container"

--- a/src/Components/ProfileDashboard/ProfileDashboard.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.jsx
@@ -14,6 +14,7 @@ import Assignments from './Assignments';
 import SavedSearches from './SavedSearches/SavedSearchesWrapper';
 import PermissionsWrapper from '../../Containers/PermissionsWrapper';
 import BackButton from '../BackButton';
+import BoxShadow from '../BoxShadow';
 
 const ProfileDashboard = ({
   userProfile, isLoading, notifications, assignment, assignmentIsLoading, isPublic,
@@ -38,13 +39,13 @@ const ProfileDashboard = ({
                   columns={columns[0]}
                   className={'user-dashboard-section-container user-dashboard-column-1'}
                 >
-                  <div className="usa-width-one-whole user-dashboard-section current-user-section">
+                  <BoxShadow className="usa-width-one-whole user-dashboard-section current-user-section">
                     <UserProfile
                       userProfile={userProfile}
                       assignment={assignment}
                       showEditLink={!isPublic}
                     />
-                  </div>
+                  </BoxShadow>
                 </Column>
                 {isPublic ?
                   <div>
@@ -52,12 +53,12 @@ const ProfileDashboard = ({
                       columns={columns[1]}
                       className="user-dashboard-section-container user-dashboard-column-3"
                     >
-                      <div className="usa-width-one-whole user-dashboard-section assignments-section">
+                      <BoxShadow className="usa-width-one-whole user-dashboard-section assignments-section">
                         <Assignments assignments={userProfile.assignments} />
-                      </div>
-                      <div className="usa-width-one-whole user-dashboard-section bidlist-section">
+                      </BoxShadow>
+                      <BoxShadow className="usa-width-one-whole user-dashboard-section bidlist-section">
                         <BidList bids={bidList} showMoreLink={!isPublic} />
-                      </div>
+                      </BoxShadow>
                     </Column>
                   </div>
                   :
@@ -66,25 +67,25 @@ const ProfileDashboard = ({
                       columns={columns[1]}
                       className={'user-dashboard-section-container user-dashboard-column-2'}
                     >
-                      <div className="usa-width-one-whole user-dashboard-section notifications-section">
+                      <BoxShadow className="usa-width-one-whole user-dashboard-section notifications-section">
                         <Notifications notifications={notifications} />
-                      </div>
-                      <div className="usa-width-one-whole user-dashboard-section favorites-section">
+                      </BoxShadow>
+                      <BoxShadow className="usa-width-one-whole user-dashboard-section favorites-section">
                         <SavedSearches />
-                      </div>
+                      </BoxShadow>
                     </Column>
                     <Column
                       columns={columns[2]}
                       className="user-dashboard-section-container user-dashboard-column-3"
                     >
                       <PermissionsWrapper permissions="bidder">
-                        <div className="usa-width-one-whole user-dashboard-section bidlist-section">
+                        <BoxShadow className="usa-width-one-whole user-dashboard-section bidlist-section">
                           <BidList bids={bidList} showMoreLink={!isPublic} />
-                        </div>
+                        </BoxShadow>
                       </PermissionsWrapper>
-                      <div className="usa-width-one-whole user-dashboard-section favorites-section">
+                      <BoxShadow className="usa-width-one-whole user-dashboard-section favorites-section">
                         <Favorites favorites={favoritePositions} />
-                      </div>
+                      </BoxShadow>
                     </Column>
                   </div>}
               </Row>

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/UserProfileGeneralInformation.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { USER_PROFILE } from '../../../../Constants/PropTypes';
 import SectionTitle from '../../SectionTitle';
 import InformationDataPoint from '../../InformationDataPoint';
-import Status from '../Status';
 import EditProfile from '../EditProfile';
 import Avatar from '../../../Avatar';
 import StaticDevContent from '../../../StaticDevContent';
@@ -13,7 +12,6 @@ const UserProfileGeneralInformation = ({ userProfile, showEditLink, useGroup }) 
   <div className="current-user-top current-user-section-border current-user-section-container">
     <div className="section-padded-inner-container">
       <div className="avatar-group">
-        <Status />
         <Avatar
           className="dashboard-user-profile-picture"
           initials={userProfile.initials}

--- a/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/UserProfileGeneralInformation/__snapshots__/UserProfileGeneralInformation.test.jsx.snap
@@ -10,9 +10,6 @@ exports[`UserProfileGeneralInformationComponent matches snapshot 1`] = `
     <div
       className="avatar-group"
     >
-      <Status
-        hideText={false}
-      />
       <Avatar
         className="dashboard-user-profile-picture"
         display_name="John"
@@ -74,9 +71,6 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when showEditLi
     <div
       className="avatar-group"
     >
-      <Status
-        hideText={false}
-      />
       <Avatar
         className="dashboard-user-profile-picture"
         display_name="John"
@@ -138,9 +132,6 @@ exports[`UserProfileGeneralInformationComponent matches snapshot when useGroup i
     <div
       className="avatar-group"
     >
-      <Status
-        hideText={false}
-      />
       <Avatar
         className="dashboard-user-profile-picture"
         display_name="John"

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -10,6 +10,8 @@ import MediaQueryWrapper from '../MediaQuery';
 import CompareCheck from '../CompareCheck/CompareCheck';
 import LanguageList from '../LanguageList';
 import BidCount from '../BidCount';
+import BoxShadow from '../BoxShadow';
+import Handshake from '../Ribbon/Handshake';
 
 import { formatDate, propOrDefault, getPostName, getBidStatisticsObject } from '../../utilities';
 
@@ -106,44 +108,51 @@ const ResultsCard = (props) => {
   return (
     <MediaQueryWrapper breakpoint="screenMdMax" widthType="max">
       {() => (
-        <div id={id} className="results-card">
-          <Row className="header" fluid>
-            <Column columns="8">
-              <Column columns="12" className="results-card-title-link">
-                <h3>{title}</h3>
-                <Link to={`/details/${result.id}`}>View position</Link>
+        <BoxShadow>
+          <div id={id} className="results-card">
+            <Row className="header" fluid>
+              <Column columns="8">
+                <Column columns="12" className="results-card-title-link">
+                  <h3>{title}</h3>
+                  <Link to={`/details/${result.id}`}>View position</Link>
+                </Column>
+                <Column columns="12" className="results-card-title-link">
+                  <dt>Post:</dt><dd>{post}</dd>
+                </Column>
               </Column>
-              <Column columns="12" className="results-card-title-link">
-                <dt>Post:</dt><dd>{post}</dd>
+              <Column columns="4">
+                <BidCount bidStatistics={stats} altStyle />
               </Column>
-            </Column>
-            <Column columns="4">
-              <BidCount bidStatistics={stats} altStyle />
-            </Column>
-          </Row>
-          <Row id={`${id}-inner`} fluid>
-            <Column columns="6">
-              <DefinitionList items={sections[0]} />
-            </Column>
-            <Column columns="6">
-              <DefinitionList items={sections[1]} />
-            </Column>
-          </Row>
-          <Row className="footer results-card-padded-section" fluid>
-            <Column columns="6" as="section">
-              {
+            </Row>
+            <Row id={`${id}-inner`} fluid>
+              <Column columns="6">
+                <DefinitionList items={sections[0]} />
+              </Column>
+              <Column columns="4">
+                <DefinitionList items={sections[1]} />
+              </Column>
+              <Column columns="2">
+                {
+                get(stats, 'has_handshake_offered', false) && <Handshake className="ribbon-results-card" />
+              }
+              </Column>
+            </Row>
+            <Row className="footer results-card-padded-section" fluid>
+              <Column columns="6" as="section">
+                {
                 !!favorites &&
                   <Favorite {...options.favorite} />
               }
-              <CompareCheck {...options.compare} />
-            </Column>
-            <Column columns="6" as="section">
-              <div>
-                <DefinitionList items={sections[2]} />
-              </div>
-            </Column>
-          </Row>
-        </div>
+                <CompareCheck {...options.compare} />
+              </Column>
+              <Column columns="6" as="section">
+                <div>
+                  <DefinitionList items={sections[2]} />
+                </div>
+              </Column>
+            </Row>
+          </div>
+        </BoxShadow>
       )}
     </MediaQueryWrapper>
   );

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -3,26 +3,35 @@ import PropTypes from 'prop-types';
 import ResultsCondensedCardTop from '../ResultsCondensedCardTop';
 import ResultsCondensedCardBottom from '../ResultsCondensedCardBottom';
 import ResultsCondensedCardFooter from '../ResultsCondensedCardFooter';
+import BoxShadow from '../BoxShadow';
 import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY, BID_RESULTS, HOME_PAGE_CARD_TYPE } from '../../Constants/PropTypes';
 
-const ResultsCondensedCard = ({ position, favorites, bidList, type, refreshFavorites }) => (
-
-  <div className="usa-grid-full condensed-card-inner">
-    <ResultsCondensedCardTop
-      favorites={favorites}
-      position={position}
-      type={type}
-    />
-    <ResultsCondensedCardBottom
-      position={position}
-      favorites={favorites}
-      bidList={bidList}
-      refreshFavorites={refreshFavorites}
-    />
-    <ResultsCondensedCardFooter
-      position={position}
-    />
-  </div>
+const ResultsCondensedCard = (
+  {
+    position,
+    favorites,
+    bidList,
+    type,
+    refreshFavorites,
+    showBidListButton,
+  }) => (
+    <BoxShadow className="usa-grid-full condensed-card-inner">
+      <ResultsCondensedCardTop
+        favorites={favorites}
+        position={position}
+        type={type}
+      />
+      <ResultsCondensedCardBottom
+        position={position}
+        favorites={favorites}
+        bidList={bidList}
+        refreshFavorites={refreshFavorites}
+        showBidListButton={showBidListButton}
+      />
+      <ResultsCondensedCardFooter
+        position={position}
+      />
+    </BoxShadow>
 );
 
 ResultsCondensedCard.propTypes = {
@@ -31,11 +40,13 @@ ResultsCondensedCard.propTypes = {
   bidList: BID_RESULTS.isRequired,
   type: HOME_PAGE_CARD_TYPE.isRequired,
   refreshFavorites: PropTypes.bool,
+  showBidListButton: PropTypes.bool,
 };
 
 ResultsCondensedCard.defaultProps = {
   favorites: [],
   refreshFavorites: false,
+  showBidListButton: false,
 };
 
 export default ResultsCondensedCard;

--- a/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
+++ b/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
@@ -1,8 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
-<div
+<BoxShadow
+  blurRadius={10}
   className="usa-grid-full condensed-card-inner"
+  color="rgba(0,0,0,.15)"
+  inset={false}
+  is="div"
+  offsetX={3}
+  offsetY={2}
+  spreadRadius={1}
+  style={Object {}}
 >
   <ResultsCondensedCardTop
     favorites={Array []}
@@ -314,6 +322,7 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
       }
     }
     refreshFavorites={false}
+    showBidListButton={false}
     type="default"
   />
   <ResultsCondensedCardFooter
@@ -397,5 +406,5 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
       }
     }
   />
-</div>
+</BoxShadow>
 `;

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -1,38 +1,59 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import CondensedCardData from '../CondensedCardData';
 import { POSITION_DETAILS, FAVORITE_POSITIONS_ARRAY } from '../../Constants/PropTypes';
 import Favorite from '../../Containers/Favorite';
+import BidListButton from '../../Containers/BidListButton';
+import PermissionsWrapper from '../../Containers/PermissionsWrapper';
 import ResultsCondensedCardStats from '../ResultsCondensedCardStats';
 
-const ResultsCondensedCardBottom = ({ position, favorites, refreshFavorites }) => (
-  <div className="condensed-card-bottom-container">
-    <div className="usa-grid-full condensed-card-bottom">
-      <ResultsCondensedCardStats bidStatisticsArray={position.bid_statistics} />
-      <CondensedCardData position={position} />
-      <div className="usa-grid-full condensed-card-buttons-section">
-        <Favorite
-          useLongText
-          hasBorder
-          refKey={position.id}
-          compareArray={favorites}
-          useButtonClass
-          refresh={refreshFavorites}
-        />
+const ResultsCondensedCardBottom = (
+  { position,
+    favorites,
+    refreshFavorites,
+    showBidListButton,
+  }) => (
+    <div className="condensed-card-bottom-container">
+      <div className="usa-grid-full condensed-card-bottom">
+        <ResultsCondensedCardStats bidStatisticsArray={position.bid_statistics} />
+        <CondensedCardData position={position} />
+        <div className="usa-grid-full condensed-card-buttons-section">
+          <Favorite
+            useLongText
+            hideText={showBidListButton}
+            hasBorder
+            refKey={position.id}
+            compareArray={favorites}
+            useButtonClass={!showBidListButton}
+            useButtonClassSecondary={showBidListButton}
+            refresh={refreshFavorites}
+          />
+          {
+            showBidListButton &&
+            <PermissionsWrapper permissions="bidder">
+              <BidListButton
+                id={position.id}
+                disabled={!get(position, 'availability.availability', true)}
+              />
+            </PermissionsWrapper>
+          }
+        </div>
       </div>
     </div>
-  </div>
   );
 
 ResultsCondensedCardBottom.propTypes = {
   position: POSITION_DETAILS.isRequired,
   favorites: FAVORITE_POSITIONS_ARRAY.isRequired,
   refreshFavorites: PropTypes.bool,
+  showBidListButton: PropTypes.bool,
 };
 
 ResultsCondensedCardBottom.defaultProps = {
   type: 'default',
   refreshFavorites: false,
+  showBidListButton: false,
 };
 
 export default ResultsCondensedCardBottom;

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
@@ -41,4 +41,16 @@ describe('ResultsCondensedCardBottomComponent', () => {
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+
+  it('matches snapshot with bidlist button', () => {
+    const wrapper = shallow(
+      <ResultsCondensedCardBottom
+        position={resultsObject.results[0]}
+        bidList={bidListObject.results}
+        favorites={favorites}
+        showBidListButton
+      />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
 });

--- a/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardBottom/__snapshots__/ResultsCondensedCardBottom.test.jsx.snap
@@ -119,11 +119,152 @@ exports[`ResultsCondensedCardBottomComponent matches snapshot 1`] = `
           ]
         }
         hasBorder={true}
+        hideText={false}
         refKey={6}
         refresh={false}
         useButtonClass={true}
+        useButtonClassSecondary={false}
         useLongText={true}
       />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ResultsCondensedCardBottomComponent matches snapshot with bidlist button 1`] = `
+<div
+  className="condensed-card-bottom-container"
+>
+  <div
+    className="usa-grid-full condensed-card-bottom"
+  >
+    <ResultsCondensedCardStats
+      bidStatisticsArray={
+        Array [
+          Object {
+            "at_skill": 0,
+            "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+            "id": 6,
+            "in_grade": 0,
+            "in_grade_at_skill": 0,
+            "total_bids": 2,
+          },
+        ]
+      }
+    />
+    <CondensedCardData
+      position={
+        Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+              "id": 6,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 2,
+            },
+          ],
+          "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+          "classifications": Array [],
+          "create_date": "2006-09-20T00:00:00Z",
+          "current_assignment": Object {
+            "estimated_end_date": "2020-03-13T15:51:11.478084Z",
+            "start_date": "2018-03-13T15:51:11.478084Z",
+            "status": "active",
+            "tour_of_duty": "2 YRS (2 R & R)",
+            "user": "John Doe",
+          },
+          "description": Object {
+            "content": "The Office Management Specialist (OMS) for the Deputy Chief of Mission (DCM) provides office management services in this Mission of six agencies, 387 American and Locally Employed Staff (LES) positions, and 279 guard force contractors.  The OMS manages Executive Office operations and positionstains the DCM’s calendar in support of overall Mission goals and objectives.  The OMS (DCM) drafts routine correspondence, memoranda and cables as appropriate and ensures documents are cleared and delivered in a timely fashion. The OMS serves as back up to the Ambassador’s OMS.  POCs areSandra McInturff, DCM OMS, McInturffSL@state.gov, 231-77-677-7000, ext. 7452; Samue Watson, DCM, WatsonSR@state.gov, 231-77-677-7000, ext. 7452. Please submit lobbying documents to the 360 Community Lobbying Center http://appcenter.state.sbu/CLC. (Revised 1/2017)
+
+",
+            "date_created": "2018-03-08T18:00:33.241370Z",
+            "date_updated": "2018-03-13T15:55:00.018644Z",
+            "id": 90,
+            "is_editable_by_user": false,
+            "last_editing_user": null,
+            "point_of_contact": null,
+            "website": null,
+          },
+          "effective_date": "2012-10-22T00:00:00Z",
+          "grade": "06",
+          "id": 6,
+          "is_highlighted": false,
+          "is_overseas": true,
+          "languages": Array [],
+          "latest_bidcycle": Object {
+            "active": true,
+            "cycle_deadline_date": "2018-04-13T15:51:10.980554Z",
+            "cycle_end_date": "2018-06-13T15:51:10.980554Z",
+            "cycle_start_date": "2017-12-13T15:51:10.980554Z",
+            "id": 1,
+            "name": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+          },
+          "organization": "(MONROVIA) MONROVIA LIBERIA",
+          "position_number": "10034001",
+          "post": Object {
+            "code": "LI6000000",
+            "cost_of_living_adjustment": 30,
+            "danger_pay": 0,
+            "differential_rate": 30,
+            "has_consumable_allowance": true,
+            "has_service_needs_differential": true,
+            "id": 160,
+            "location": Object {
+              "city": "Freetown",
+              "code": "00A",
+              "country": "Sierra Leone",
+              "id": 103,
+              "state": "",
+            },
+            "obc_id": null,
+            "rest_relaxation_point": "Paris",
+            "tour_of_duty": "2 YRS (2 R & R)",
+          },
+          "posted_date": "2012-10-22T00:00:00Z",
+          "representation": "[10034001] OMS (DCM) (Monrovia, Liberia)",
+          "skill": "OFFICE MANAGEMENT (9017)",
+          "status": null,
+          "status_code": null,
+          "title": "OMS (DCM)",
+          "tour_of_duty": null,
+          "update_date": "2017-06-08T00:00:00Z",
+        }
+      }
+    />
+    <div
+      className="usa-grid-full condensed-card-buttons-section"
+    >
+      <Connect(FavoriteContainer)
+        compareArray={
+          Array [
+            Object {
+              "id": 1,
+              "representation": "[00003026] OMS (COM) (Freetown, Sierra Leone)",
+            },
+            Object {
+              "id": 4,
+              "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
+            },
+          ]
+        }
+        hasBorder={true}
+        hideText={true}
+        refKey={6}
+        refresh={false}
+        useButtonClass={false}
+        useButtonClassSecondary={true}
+        useLongText={true}
+      />
+      <Connect(PermissionsWrapper)
+        permissions="bidder"
+      >
+        <Connect(BidListButtonContainer)
+          disabled={false}
+          id={6}
+        />
+      </Connect(PermissionsWrapper)>
     </div>
   </div>
 </div>

--- a/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.jsx
+++ b/src/Components/ResultsCondensedCardStats/ResultsCondensedCardStats.jsx
@@ -7,7 +7,7 @@ const ResultsCondensedCardStats = ({ bidStatisticsArray }) => {
   const bidStatistics = getBidStatisticsObject(bidStatisticsArray);
   return (
     <div className="condensed-card-footer condensed-card-statistics">
-      <div className="usa-grid-full">
+      <div className="usa-grid-full condensed-card-statistics-inner">
         <BidCount bidStatistics={bidStatistics} />
       </div>
     </div>

--- a/src/Components/ResultsCondensedCardStats/__snapshots__/ResultsCondensedCardStats.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardStats/__snapshots__/ResultsCondensedCardStats.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`ResultsCondensedCardStatsComponent matches snapshot 1`] = `
   className="condensed-card-footer condensed-card-statistics"
 >
   <div
-    className="usa-grid-full"
+    className="usa-grid-full condensed-card-statistics-inner"
   >
     <BidCount
       altStyle={false}

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { get } from 'lodash';
 import FontAwesome from 'react-fontawesome';
+import Handshake from '../Ribbon/Handshake';
 import { POSITION_DETAILS, HOME_PAGE_CARD_TYPE } from '../../Constants/PropTypes';
+import { NO_POST } from '../../Constants/SystemMessages';
+import { getPostName, getBidStatisticsObject } from '../../utilities';
 
 const ResultsCondensedCardTop = ({ position, type }) => {
   let icon = '';
@@ -12,25 +16,30 @@ const ResultsCondensedCardTop = ({ position, type }) => {
     cardTopClass = 'card-top-alternate';
     useType = true;
   }
+  const stats = getBidStatisticsObject(position.bid_statistics);
+  const hasHandshake = get(stats, 'has_handshake_offered', false);
   return (
     <div className={`usa-grid-full condensed-card-top ${cardTopClass}`}>
       <div className="usa-grid-full condensed-card-top-header-container">
         <div
           className={
-            'usa-width-two-thirds condensed-card-top-header condensed-card-top-header-left'
+            'usa-width-one-whole condensed-card-top-header condensed-card-top-header-left'
           }
         >
           {useType && <span><FontAwesome name={icon} /> </span>}
-          <h3>{position.title}</h3>
-        </div>
-        <div
-          className="usa-width-one-third condensed-card-top-header condensed-card-top-header-right"
-        >
-          <dt>Grade:</dt> <dd>{position.grade}</dd>
+          <h3>{position.title}</h3> <Link to={`/details/${position.id}`}>View position</Link>
         </div>
       </div>
-      <div className="usa-grid-full">
-        <Link to={`/details/${position.id}`}>View position</Link>
+      <div className="usa-grid-full post-ribbon-container">
+        <div>
+          <span><span className="title">Post:</span> <span className="data">{getPostName(position.post, NO_POST)}</span></span>
+        </div>
+        {
+          hasHandshake &&
+            <div>
+              <Handshake className="ribbon-condensed-card" />
+            </div>
+        }
       </div>
     </div>
   );

--- a/src/Components/ResultsCondensedCardTop/__snapshots__/ResultsCondensedCardTop.test.jsx.snap
+++ b/src/Components/ResultsCondensedCardTop/__snapshots__/ResultsCondensedCardTop.test.jsx.snap
@@ -8,33 +8,38 @@ exports[`ResultsCondensedCardTopComponent matches snapshot 1`] = `
     className="usa-grid-full condensed-card-top-header-container"
   >
     <div
-      className="usa-width-two-thirds condensed-card-top-header condensed-card-top-header-left"
+      className="usa-width-one-whole condensed-card-top-header condensed-card-top-header-left"
     >
       <h3>
         OMS (DCM)
       </h3>
-    </div>
-    <div
-      className="usa-width-one-third condensed-card-top-header condensed-card-top-header-right"
-    >
-      <dt>
-        Grade:
-      </dt>
        
-      <dd>
-        06
-      </dd>
+      <Link
+        replace={false}
+        to="/details/6"
+      >
+        View position
+      </Link>
     </div>
   </div>
   <div
-    className="usa-grid-full"
+    className="usa-grid-full post-ribbon-container"
   >
-    <Link
-      replace={false}
-      to="/details/6"
-    >
-      View position
-    </Link>
+    <div>
+      <span>
+        <span
+          className="title"
+        >
+          Post:
+        </span>
+         
+        <span
+          className="data"
+        >
+          Freetown, Sierra Leone
+        </span>
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -47,7 +52,7 @@ exports[`ResultsCondensedCardTopComponent matches snapshot when type is serviceN
     className="usa-grid-full condensed-card-top-header-container"
   >
     <div
-      className="usa-width-two-thirds condensed-card-top-header condensed-card-top-header-left"
+      className="usa-width-one-whole condensed-card-top-header condensed-card-top-header-left"
     >
       <span>
         <FontAwesome
@@ -58,28 +63,33 @@ exports[`ResultsCondensedCardTopComponent matches snapshot when type is serviceN
       <h3>
         OMS (DCM)
       </h3>
-    </div>
-    <div
-      className="usa-width-one-third condensed-card-top-header condensed-card-top-header-right"
-    >
-      <dt>
-        Grade:
-      </dt>
        
-      <dd>
-        06
-      </dd>
+      <Link
+        replace={false}
+        to="/details/6"
+      >
+        View position
+      </Link>
     </div>
   </div>
   <div
-    className="usa-grid-full"
+    className="usa-grid-full post-ribbon-container"
   >
-    <Link
-      replace={false}
-      to="/details/6"
-    >
-      View position
-    </Link>
+    <div>
+      <span>
+        <span
+          className="title"
+        >
+          Post:
+        </span>
+         
+        <span
+          className="data"
+        >
+          Freetown, Sierra Leone
+        </span>
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/src/Components/Ribbon/Handshake/Handshake.jsx
+++ b/src/Components/Ribbon/Handshake/Handshake.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Ribbon from '../Ribbon';
+
+const Handshake = ({ ...props }) => (
+  <Ribbon icon="handshake-o" text="Handshake" type="primary" {...props} />
+);
+
+export default Handshake;

--- a/src/Components/Ribbon/Handshake/Handshake.test.jsx
+++ b/src/Components/Ribbon/Handshake/Handshake.test.jsx
@@ -1,0 +1,11 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Handshake from './Handshake';
+
+describe('HandshakeComponent', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<Handshake />);
+
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Components/Ribbon/Handshake/index.js
+++ b/src/Components/Ribbon/Handshake/index.js
@@ -1,0 +1,1 @@
+export { default } from './Handshake';

--- a/src/Components/Ribbon/Ribbon.jsx
+++ b/src/Components/Ribbon/Ribbon.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FA from 'react-fontawesome';
+
+const Ribbon = ({ type, className, icon, text, cutSide, containerProps }) => (
+  <div className={`ribbon-outer-container ribbon-outer-container-cut-${cutSide} ${className}`} {...containerProps}>
+    <div className={`ribbon ribbon-${type} ribbon-cut-${cutSide}`}>
+      <FA name={icon} /><span className="text">{text}</span>
+    </div>
+  </div>
+);
+
+
+Ribbon.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.string,
+  text: PropTypes.string,
+  containerProps: PropTypes.shape({}),
+  type: PropTypes.oneOf(['primary', 'secondary']),
+  cutSide: PropTypes.oneOf(['left', 'right']),
+};
+
+Ribbon.defaultProps = {
+  className: '',
+  icon: 'handshake',
+  text: '',
+  containerProps: {},
+  type: 'primary',
+  cutSide: 'left',
+};
+
+export default Ribbon;

--- a/src/Components/Ribbon/Ribbon.test.jsx
+++ b/src/Components/Ribbon/Ribbon.test.jsx
@@ -1,0 +1,80 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import Ribbon from './Ribbon';
+
+describe('RibbonComponent', () => {
+  const props = {
+    type: 'primary',
+    className: '',
+    icon: '',
+    text: '',
+    cutSide: 'left',
+    containerProps: {},
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(<Ribbon {...props} />);
+
+    expect(wrapper).toBeDefined();
+  });
+
+  it('creates class names', () => {
+    const props$ = {
+      ...props,
+      className: 'custom-class',
+      cutSide: 'right',
+      type: 'primary',
+    };
+    const wrapper = shallow(<Ribbon {...props$} />);
+
+    expect(wrapper.find('div').at(0).props().className)
+      .toBe(`ribbon-outer-container ribbon-outer-container-cut-${props$.cutSide} ${props$.className}`);
+    expect(wrapper.find('div').at(1).props().className)
+      .toBe(`ribbon ribbon-${props$.type} ribbon-cut-${props$.cutSide}`);
+  });
+
+  it('passes the correct icon name', () => {
+    const props$ = {
+      ...props,
+      icon: 'message',
+    };
+    const wrapper = shallow(<Ribbon {...props$} />);
+
+    expect(wrapper.find('FontAwesome').at(0).props().name)
+      .toBe(props$.icon);
+  });
+
+  it('passes the correct text', () => {
+    const props$ = {
+      ...props,
+      text: 'Ribbon text',
+    };
+    const wrapper = shallow(<Ribbon {...props$} />);
+
+    expect(wrapper.find('span').text())
+      .toBe(props$.text);
+  });
+
+  it('spreads the containerProps', () => {
+    const props$ = {
+      ...props,
+      containerProps: {
+        alt: 'alt text',
+        tabIndex: 0,
+      },
+    };
+    const wrapper = shallow(<Ribbon {...props$} />);
+
+    Object.keys(props$.containerProps).map(m => (
+      expect(wrapper.find('div').at(0).props()[m])
+        .toBe(props$.containerProps[m])
+    ));
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<Ribbon {...props} />);
+
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/Ribbon/__snapshots__/Ribbon.test.jsx.snap
+++ b/src/Components/Ribbon/__snapshots__/Ribbon.test.jsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RibbonComponent matches snapshot 1`] = `
+<div
+  className="ribbon-outer-container ribbon-outer-container-cut-left "
+>
+  <div
+    className="ribbon ribbon-primary ribbon-cut-left"
+  >
+    <FontAwesome
+      name=""
+    />
+    <span
+      className="text"
+    />
+  </div>
+</div>
+`;

--- a/src/Components/Ribbon/index.js
+++ b/src/Components/Ribbon/index.js
@@ -1,0 +1,1 @@
+export { default } from './Ribbon';

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { CSVDownload } from 'react-csv';
+import { CSVLink } from 'react-csv';
 import queryString from 'query-string';
 import { POSITION_SEARCH_SORTS } from '../../Constants/Sort';
 import { fetchResultData } from '../../actions/results';
@@ -52,7 +52,11 @@ class SearchResultsExportLink extends Component {
     };
     fetchResultData(queryString.stringify(query)).then((results) => {
       const data = processData(results.results);
-      this.setState({ data });
+      this.setState({ data }, () => {
+        // click the CSVLink component to trigger the CSV download
+        // This is needed for the download to work in Edge.
+        this.csvLink.link.click();
+      });
     });
   }
 
@@ -60,10 +64,8 @@ class SearchResultsExportLink extends Component {
     const { data } = this.state;
     return (
       <div>
-        <button className="usa-button-secondary" onClick={this.onClick}>Download</button>
-        {
-          data && <CSVDownload target="" filename={this.props.filename} data={data} headers={HEADERS} />
-        }
+        <button className="usa-button-secondary" onClick={this.onClick}>Export</button>
+        <CSVLink ref={(x) => { this.csvLink = x; }} target="_blank" filename={this.props.filename} data={data} headers={HEADERS} />
       </div>
     );
   }

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
@@ -24,11 +24,11 @@ describe('SearchResultsExportLink', () => {
     expect(fetchResultDataStub.calledOnce).toBe(true);
   });
 
-  it('shows download component when state has data', () => {
+  it('shows link component when state has data', () => {
     const wrapper = shallow(<SearchResultsExportLink />);
     wrapper.setState({ data: 'test' });
     wrapper.update();
-    expect(wrapper.find('CSVDownload').prop('data')).toBeTruthy();
+    expect(wrapper.find('CSVLink').prop('data')).toBeTruthy();
   });
 
   it('matches snapshot', () => {

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -6,7 +6,71 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     className="usa-button-secondary"
     onClick={[Function]}
   >
-    Download
+    Export
   </button>
+  <CSVLink
+    asyncOnClick={false}
+    data=""
+    filename="TalentMap_search_export.csv"
+    headers={
+      Array [
+        Object {
+          "key": "title",
+          "label": "Position",
+        },
+        Object {
+          "key": "position_number",
+          "label": "Position number",
+        },
+        Object {
+          "key": "skill",
+          "label": "Skill",
+        },
+        Object {
+          "key": "grade",
+          "label": "Grade",
+        },
+        Object {
+          "key": "bureau",
+          "label": "Bureau",
+        },
+        Object {
+          "key": "post.location.city",
+          "label": "Post city",
+        },
+        Object {
+          "key": "post.location.country",
+          "label": "Post country",
+        },
+        Object {
+          "key": "post.tour_of_duty",
+          "label": "Tour of duty",
+        },
+        Object {
+          "key": "languages[0].representation",
+          "label": "Language",
+        },
+        Object {
+          "key": "post.differential_rate",
+          "label": "Post differential",
+        },
+        Object {
+          "key": "post.danger_pay",
+          "label": "Danger pay",
+        },
+        Object {
+          "key": "estimated_end_date",
+          "label": "TED",
+        },
+        Object {
+          "key": "current_assignment.user",
+          "label": "Incumbent",
+        },
+      ]
+    }
+    separator=","
+    target="_blank"
+    uFEFF={true}
+  />
 </div>
 `;

--- a/src/Constants/EndpointParams.js
+++ b/src/Constants/EndpointParams.js
@@ -2,7 +2,7 @@
 
 export const ENDPOINT_PARAMS = {
   skill: 'skill__code__in',
-  language: 'languages__language__code__in',
+  language: 'language_codes',
   grade: 'grade__code__in',
   tod: 'post__tour_of_duty__code__in',
   org: 'bureau__code__in',
@@ -21,6 +21,7 @@ export const ENDPOINT_PARAMS = {
 // any properties that we want to abstract to a common name
 export const COMMON_PROPERTIES = {
   posted: 'posted_date',
+  NULL_LANGUAGE: 'NONE',
 };
 
 // Take our custom query param from the Bidder Portfolio navigation and convert them to queries

--- a/src/Constants/SetType.test.jsx
+++ b/src/Constants/SetType.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { omit, pick } from 'lodash';
+import SetType from './SetType';
+
+describe('PropTypes', () => {
+  const props = {
+    a: new Set(),
+    b: 1,
+    c: () => {},
+    d: {},
+    e: [],
+    f: null,
+    g: undefined,
+    h: 'h',
+    i: <div />,
+    j: 0,
+    k: { method: 1 /* some non-function */ },
+  };
+
+  const shouldReturnNull = ['a', 'f', 'g'];
+
+  Object.keys(pick(props, shouldReturnNull)).map(k => (
+    it(`should return null for Set, null, and undefined (key = ${k}: ${JSON.stringify(props[k])})`, () => {
+      const output = SetType(props, k, 'component');
+      expect(output).toBeNull();
+    })
+  ));
+
+  Object.keys(omit(props, shouldReturnNull)).map(k => (
+    it(`should return an error if type !== Set (key = ${k}: ${JSON.stringify(props[k])})`, () => {
+      const output = SetType(props, k, 'component');
+      expect(output.toString()).toEqual((expect.stringMatching(/^(Error)/)));
+    })
+  ));
+
+  it('return an error if the prop is required and a null value is provided', () => {
+    const output = SetType.isRequired(props, 'f', 'component');
+    expect(output.toString()).toEqual((expect.stringMatching(/^(Error)/)));
+  });
+
+  it('return a null if the prop is required and a valid value is provided', () => {
+    const output = SetType.isRequired(props, 'a', 'component');
+    expect(output).toBeNull();
+  });
+});

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -1,3 +1,5 @@
+import FavoriteSuccess from '../Components/FavoriteMessages/Success';
+
 export const DEFAULT_TEXT = 'None listed';
 
 export const NO_ASSIGNMENT_DATE = DEFAULT_TEXT;
@@ -36,6 +38,14 @@ export const DELETE_BID_ITEM_SUCCESS = 'Bid successfully removed.';
 export const DELETE_BID_ITEM_ERROR = 'Error trying to delete this bid.';
 export const ADD_BID_ITEM_SUCCESS = 'Bid successfully added.';
 export const ADD_BID_ITEM_ERROR = 'Error trying to add this bid.';
+
+export const ADD_FAVORITE_TITLE = 'Favorite Added';
+export const DELETE_FAVORITE_TITLE = 'Favorite Removed';
+export const ERROR_FAVORITE_TITLE = 'Favorite Error';
+export const DELETE_FAVORITE_SUCCESS = pos => `${pos.title} (${pos.position_number}) has been successfully removed from favorites.`;
+export const DELETE_FAVORITE_ERROR = () => "We're experiencing an error attemtping to remove this position to your Favorites. Please try again.";
+export const ADD_FAVORITE_SUCCESS = pos => FavoriteSuccess({ pos });
+export const ADD_FAVORITE_ERROR = () => "We're experiencing an error attemtping to add this position to your Favorites. Please try again.";
 
 export const ACCEPT_BID_SUCCESS = 'Bid successfully accepted.';
 export const ACCEPT_BID_ERROR = 'Error trying to accept this bid.';

--- a/src/Containers/BidListButton/BidListButton.jsx
+++ b/src/Containers/BidListButton/BidListButton.jsx
@@ -1,26 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { SetType, BID_LIST } from '../../Constants/PropTypes';
 import { toggleBidPosition } from '../../actions/bidList';
 import BidListButton from '../../Components/BidListButton';
-import { SetType } from '../../Constants/PropTypes';
 
-const BidListButtonContainer = ({ toggleBid, isLoading, id, ...rest }) => (
-  <BidListButton toggleBidPosition={toggleBid} id={id} isLoading={isLoading.has(id)} {...rest} />
-  );
+const BidListButtonContainer = ({ toggleBid, isLoading, id, compareArray, ...rest }) => (
+  <BidListButton
+    toggleBidPosition={toggleBid}
+    id={id}
+    isLoading={isLoading.has(id)}
+    compareArray={compareArray.results}
+    {...rest}
+  />
+);
 
 BidListButtonContainer.propTypes = {
   toggleBid: PropTypes.func.isRequired,
   isLoading: SetType,
   id: PropTypes.number.isRequired,
+  compareArray: BID_LIST.isRequired,
 };
 
 BidListButtonContainer.defaultProps = {
   isLoading: new Set(),
+  compareArray: { results: [] },
 };
 
 export const mapStateToProps = state => ({
   isLoading: state.bidListToggleIsLoading,
+  compareArray: state.bidListFetchDataSuccess,
 });
 
 export const mapDispatchToProps = dispatch => ({

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -12,7 +12,7 @@ import { COMPARE_LIST, POSITION_SEARCH_RESULTS, BID_LIST, SetType } from '../../
 import { POSITION_RESULTS_OBJECT } from '../../Constants/DefaultProps';
 import { LOGIN_REDIRECT } from '../../login/routes';
 
-class Compare extends Component {
+export class Compare extends Component {
   constructor(props) {
     super(props);
     this.onToggle = this.onToggle.bind(this);

--- a/src/Containers/Compare/Compare.test.jsx
+++ b/src/Containers/Compare/Compare.test.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
 import TestUtils from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { testDispatchFunctions } from '../../testUtilities/testUtilities';
-import Compare, { mapDispatchToProps } from './Compare';
+import Compare, { Compare as CompareComponent, mapDispatchToProps } from './Compare';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -19,6 +21,27 @@ describe('Main', () => {
       />
     </MemoryRouter></Provider>);
     expect(compare).toBeDefined();
+  });
+
+  it('passes the correct value to getComparisons when onToggle is called', () => {
+    const compare = shallow(
+      <CompareComponent
+        isAuthorized={() => true}
+        onNavigateTo={() => {}}
+        match={{ params: { ids: '1,2,3' } }}
+        fetchData={() => {}}
+        hasErrored={false}
+        isLoading={false}
+        fetchFavorites={() => {}}
+        fetchBidList={() => {}}
+      />,
+    );
+    const instance = compare.instance();
+    const input = '1';
+    const getComparisonsSpy = sinon.spy(instance, 'getComparisons');
+    instance.onToggle(input);
+    const exp = '2,3';
+    expect(getComparisonsSpy.getCall(0).args[0]).toBe(exp);
   });
 
   it('can handle authentication redirects', () => {

--- a/src/Containers/Favorite/Favorite.jsx
+++ b/src/Containers/Favorite/Favorite.jsx
@@ -3,23 +3,36 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { userProfileToggleFavoritePosition } from '../../actions/userProfile';
 import Favorite from '../../Components/Favorite';
+import { SetType } from '../../Constants/PropTypes';
 
 const FavoriteContainer = ({
   onToggle,
   isLoading,
   hasErrored,
+  refKey,
   ...rest }) => (
-    <Favorite onToggle={onToggle} isLoading={isLoading} hasErrored={hasErrored} {...rest} />
-);
+    <Favorite
+      onToggle={onToggle}
+      isLoading={isLoading.has(refKey)}
+      hasErrored={hasErrored}
+      refKey={refKey}
+      {...rest}
+    />
+  );
 
 FavoriteContainer.propTypes = {
   onToggle: PropTypes.func.isRequired,
-  isLoading: PropTypes.bool.isRequired,
+  isLoading: SetType,
   hasErrored: PropTypes.bool.isRequired,
+  refKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string.isRequired]).isRequired,
+};
+
+FavoriteContainer.defaultProps = {
+  isLoading: new Set(),
 };
 
 export const mapStateToProps = state => ({
-  isLoading: state.userProfileFavoritePositionIsLoading || false,
+  isLoading: state.userProfileFavoritePositionIsLoading,
   hasErrored: state.userProfileFavoritePositionHasErrored || false,
 });
 

--- a/src/Containers/Favorite/Favorite.test.jsx
+++ b/src/Containers/Favorite/Favorite.test.jsx
@@ -6,7 +6,7 @@ import Favorite, { mapDispatchToProps } from './Favorite';
 describe('Favorite', () => {
   const props = {
     onToggle: () => {},
-    isLoading: false,
+    isLoading: new Set(),
     hasErrored: false,
     refKey: 'key',
     compareArray: [],

--- a/src/Containers/Toast/Toast.jsx
+++ b/src/Containers/Toast/Toast.jsx
@@ -17,12 +17,13 @@ export class Toast extends Component {
     }
   }
 
-  notify({ type = 'success', message = 'Message' }) { // eslint-disable-line
-    let title;
-    if (type === 'success') { title = 'Success'; }
-    if (type === 'error') { title = 'Error'; }
+  notify({ type = 'success', message = 'Message', title = '' }) { // eslint-disable-line
+    let title$;
+    if (type === 'success') { title$ = 'Success'; }
+    if (type === 'error') { title$ = 'Error'; }
+    if (title) { title$ = title; }
     toast[type](
-      <Alert type={type} title={title} messages={[{ body: message }]} />,
+      <Alert type={type} title={title$} messages={[{ body: message }]} />,
     );
   }
 
@@ -36,7 +37,8 @@ export class Toast extends Component {
 Toast.propTypes = {
   toastData: PropTypes.shape({
     type: PropTypes.string,
-    message: PropTypes.string,
+    message: PropTypes.node,
+    title: PropTypes.string,
   }),
 };
 

--- a/src/actions/favoritePositions.js
+++ b/src/actions/favoritePositions.js
@@ -31,9 +31,9 @@ export function favoritePositionsFetchData(sortType) {
     api.get(url)
       .then(response => response.data)
       .then((results) => {
+        dispatch(favoritePositionsFetchDataSuccess(results));
         dispatch(favoritePositionsHasErrored(false));
         dispatch(favoritePositionsIsLoading(false));
-        dispatch(favoritePositionsFetchDataSuccess(results));
       })
       .catch(() => {
         dispatch(favoritePositionsHasErrored(true));

--- a/src/actions/filters/filters.js
+++ b/src/actions/filters/filters.js
@@ -1,3 +1,4 @@
+import { union } from 'lodash';
 import api from '../../api';
 import { ASYNC_PARAMS, ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 import { removeDuplicates } from '../../utilities';
@@ -218,7 +219,8 @@ export function filtersFetchData(items = { filters: [] }, queryParams = {}, save
         api.get(`/${item.item.endpoint}`)
           .then((response) => {
             const itemFilter = Object.assign({}, item);
-            itemFilter.data = response.data.results;
+            // We have a mix of server-supplied and hard-coded data, so we combine them with union.
+            itemFilter.data = union(response.data.results, item.initialData);
             return itemFilter;
           })
       ),

--- a/src/actions/filters/helpers.js
+++ b/src/actions/filters/helpers.js
@@ -1,4 +1,5 @@
 import { getPostName } from '../../utilities';
+import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 
 // Attempt to map the non-numeric grade codes to a full description.
 // If no match is found, return the unmodified code.
@@ -29,7 +30,11 @@ export function getFilterCustomDescription(filterItem, filterItemObject) {
     case 'bidCycle':
       return filterItemObject.name;
     case 'language':
-      return `${filterItemObject.formal_description} (${filterItemObject.code})`;
+      // language code NONE gets displayed differently
+      return filterItemObject.code === COMMON_PROPERTIES.NULL_LANGUAGE ?
+        filterItemObject.customDescription
+        :
+        `${filterItemObject.formal_description} (${filterItemObject.code})`;
     case 'grade':
       return getCustomGradeDescription(filterItemObject.code);
     case 'postDiff':

--- a/src/actions/toast.js
+++ b/src/actions/toast.js
@@ -1,13 +1,15 @@
-export function toastSuccess(toast) {
+export function toastSuccess(toast, title) {
   return {
     type: 'TOAST_NOTIFICATION_SUCCESS',
     toast,
+    title,
   };
 }
 
-export function toastError(toast) {
+export function toastError(toast, title) {
   return {
     type: 'TOAST_NOTIFICATION_ERROR',
     toast,
+    title,
   };
 }

--- a/src/reducers/filters/filters.js
+++ b/src/reducers/filters/filters.js
@@ -1,4 +1,4 @@
-import { ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
+import { COMMON_PROPERTIES, ENDPOINT_PARAMS } from '../../Constants/EndpointParams';
 
 // Set what filters we want to fetch
 const items =
@@ -49,6 +49,15 @@ const items =
           text: 'Choose languages',
         },
         data: [
+        ],
+        // Allow users to include languages with no code. This option is not supplied from
+        // the endpoint, so we define it here.
+        initialData: [
+          {
+            code: COMMON_PROPERTIES.NULL_LANGUAGE,
+            short_description: 'No language requirement',
+            custom_description: 'No language requirement',
+          },
         ],
       },
       {

--- a/src/reducers/toast/toast.js
+++ b/src/reducers/toast/toast.js
@@ -1,9 +1,9 @@
-export default function toast(state = { type: 'success', message: '' }, action) {
+export default function toast(state = { type: 'success', message: '', title: '' }, action) {
   switch (action.type) {
     case 'TOAST_NOTIFICATION_SUCCESS':
-      return { type: 'success', message: action.toast };
+      return { type: 'success', message: action.toast, title: action.title };
     case 'TOAST_NOTIFICATION_ERROR':
-      return { type: 'error', message: action.toast };
+      return { type: 'error', message: action.toast, title: action.title };
     default:
       return state;
   }

--- a/src/reducers/userProfile/userProfile.js
+++ b/src/reducers/userProfile/userProfile.js
@@ -32,10 +32,16 @@ export function userProfileFavoritePositionHasErrored(state = false, action) {
       return state;
   }
 }
-export function userProfileFavoritePositionIsLoading(state = false, action) {
+export function userProfileFavoritePositionIsLoading(state = new Set(), action) {
+  const newSet = new Set(state);
   switch (action.type) {
     case 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING':
-      return action.userProfileFavoritePositionIsLoading;
+      if (action.userProfileFavoritePositionIsLoading.bool) {
+        newSet.add(action.userProfileFavoritePositionIsLoading.id);
+        return newSet;
+      }
+      newSet.delete(action.userProfileFavoritePositionIsLoading.id);
+      return newSet;
     default:
       return state;
   }

--- a/src/reducers/userProfile/userProfile.test.js
+++ b/src/reducers/userProfile/userProfile.test.js
@@ -14,10 +14,14 @@ describe('reducers', () => {
   });
 
   it('can set reducer USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', () => {
-    expect(reducers.userProfileFavoritePositionHasErrored(false, { type: 'USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', userProfileFavoritePositionHasErrored: true })).toBe(true);
+    expect(reducers.userProfileFavoritePositionHasErrored(new Set(), { type: 'USER_PROFILE_FAVORITE_POSITION_HAS_ERRORED', userProfileFavoritePositionHasErrored: true })).toBe(true);
   });
 
-  it('can set reducer USER_PROFILE_FAVORITE_POSITION_IS_LOADING', () => {
-    expect(reducers.userProfileFavoritePositionIsLoading(false, { type: 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING', userProfileFavoritePositionIsLoading: true })).toBe(true);
+  it('can set reducer USER_PROFILE_FAVORITE_POSITION_IS_LOADING to add an id', () => {
+    expect(reducers.userProfileFavoritePositionIsLoading(new Set(), { type: 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING', userProfileFavoritePositionIsLoading: { bool: true, id: 1 } })).toEqual(new Set([1]));
+  });
+
+  it('can set reducer USER_PROFILE_FAVORITE_POSITION_IS_LOADING to remove an id', () => {
+    expect(reducers.userProfileFavoritePositionIsLoading(new Set([1]), { type: 'USER_PROFILE_FAVORITE_POSITION_IS_LOADING', userProfileFavoritePositionIsLoading: { bool: false, id: 1 } })).toEqual(new Set());
   });
 });

--- a/src/sass/_bidListButton.scss
+++ b/src/sass/_bidListButton.scss
@@ -1,5 +1,4 @@
 .bid-list-button {
-  padding: 1.5rem 4rem;
 
   .button-icon {
     color: $color-white;

--- a/src/sass/_bidTracker.scss
+++ b/src/sass/_bidTracker.scss
@@ -593,7 +593,14 @@ $draft-icon-offset: 120px;
 }
 
 .bid-tracker-standby-container {
+  $link-color: #2B4559;
+
   display: flex;
+  opacity: .75; // lowest opacity without violating 4.5:1 contrast ratio
+
+  a:link {
+    color: $link-color; // opacity lightens normal link color below the required 4.5:1 ratio
+  }
 
   .bid-tracker-standby-inner-container {
     display: flex;

--- a/src/sass/_buttons.scss
+++ b/src/sass/_buttons.scss
@@ -144,8 +144,8 @@
   &.button-text-hidden {
     margin-top: 0;
     padding-bottom: 11.5px;
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-left: 14px;
+    padding-right: 14px;
     padding-top: 11.5px;
 
     .spinner-white,
@@ -155,6 +155,7 @@
 
     .fa {
       margin-right: 0;
+      padding-right: 0;
     }
   }
 

--- a/src/sass/_compare.scss
+++ b/src/sass/_compare.scss
@@ -10,10 +10,6 @@
   .bid-list-button {
     min-width: 100%;
     padding: .75em 1em;
-
-    .button-icon {
-      display: none;
-    }
   }
 
   .post-data-button {

--- a/src/sass/_condensedCard.scss
+++ b/src/sass/_condensedCard.scss
@@ -67,13 +67,25 @@ $condensed-card-data-padding: 15px 20px 9px;
     background-color: $blue-primary;
     border-bottom: 1px solid $color-gray-lightest;
     color: $color-white;
-    overflow: hidden;
     padding: $condensed-card-padding;
     position: relative;
+    width: 100%;
+
+    a,
+    .data {
+      font-weight: 300;
+    }
 
     a {
       color: $color-white;
     }
+  }
+
+  .post-ribbon-container {
+    display: flex;
+
+    div:nth-of-type(1) { flex: 3; }
+    div:nth-of-type(2) { flex: 2; }
   }
 
   .card-top-alternate {
@@ -96,10 +108,14 @@ $condensed-card-data-padding: 15px 20px 9px;
   .condensed-card-top-header-left {
     float: left;
 
+    a {
+      display: inline-block;
+    }
+
     h3 {
       display: inline;
       font-family: inherit;
-      font-size: inherit;
+      font-size: 1.1em;
       font-weight: inherit;
       line-height: inherit;
       margin-bottom: inherit;
@@ -132,26 +148,48 @@ $condensed-card-data-padding: 15px 20px 9px;
 
   .condensed-card-bottom-container {
     background-color: $color-white;
+    flex-grow: 1;
     padding: $condensed-card-data-padding;
     padding-bottom: 5px;
     position: relative;
   }
 
   .condensed-card-inner {
+    display: flex;
+    flex-direction: column;
     height: 100%;
     position: relative;
   }
 
   .condensed-card-bottom {
+    display: flex;
+    flex-direction: column;
     font-size: 16px;
+    height: 100%;
   }
 
   .condensed-card-buttons-section {
     margin-bottom: 10px;
+    margin-left: 0;
+    margin-right: 0;
+
+    button {
+      height: 44px;
+      margin-top: 0;
+    }
+  }
+
+  .condensed-card-statistics-inner {
+    margin-left: 0;
+    margin-right: 0;
   }
 
   .condensed-card-statistics {
     border-top: 0;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: flex-end;
     position: relative;
 
     .bid-count-list-item {
@@ -182,8 +220,11 @@ $condensed-card-data-padding: 15px 20px 9px;
   }
 
   .condensed-card-data {
+    flex-grow: 1;
     line-height: 1.4em;
     margin-bottom: 20px;
+    margin-left: 0;
+    margin-right: 0;
 
     a {
       color: $blue-primary;
@@ -302,4 +343,3 @@ $condensed-card-data-padding: 15px 20px 9px;
   display: flex;
   flex-wrap: wrap;
 }
-

--- a/src/sass/_details.scss
+++ b/src/sass/_details.scss
@@ -1,3 +1,13 @@
+.position-details-outer-container {
+  position: relative;
+
+  .handshake-offset-container {
+    left: -3px;
+    position: absolute;
+    top: -37px;
+  }
+}
+
 .position-details-header-container {
   color: $color-white;
   position: relative;

--- a/src/sass/_ribbon.scss
+++ b/src/sass/_ribbon.scss
@@ -1,0 +1,60 @@
+$ribbon-shadow-color: rgba(112, 112, 112, .5);
+
+.ribbon {
+  color: $color-black;
+  display: flex;
+  font-family: 'Merriweather';
+  font-size: 1.3rem;
+  font-weight: bold;
+  padding-bottom: 5px;
+  padding-top: 6px;
+
+  .fa {
+    font-size: 1.8rem;
+    margin-right: .5em;
+  }
+
+  .text {
+    margin-top: .12em;
+  }
+}
+
+.ribbon-primary {
+  background-color: $tertiary-gold-lighter;
+}
+
+.ribbon-secondary {
+  background-color: $blue-primary-darkest;
+  color: $color-white;
+}
+
+.ribbon-outer-container-cut-left {
+  box-shadow: 3px 4px 4px -4px $ribbon-shadow-color;
+}
+
+.ribbon-outer-container-cut-right {
+  box-shadow: -3px 4px 4px -4px $ribbon-shadow-color;
+}
+
+.ribbon-cut-left {
+  clip-path: polygon(9% 0, 100% 0, 100% 100%, 0 100%, 0 100%);
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.ribbon-cut-right {
+  clip-path: polygon(0 0, 100% 0, 91% 100%, 0 100%, 0 100%);
+  padding-left: .5em;
+  padding-right: 1em;
+}
+
+.ribbon-results-card {
+  position: absolute;
+  right: -1px;
+}
+
+.ribbon-condensed-card {
+  position: absolute;
+  right: 0;
+  z-index: $ribbon-z;
+}

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -161,13 +161,14 @@ $tm-focus-outline-offset-default: 3px;
 //* z-index
 //*
 // we'll use this section to keep track of and order them
-$autosuggest-suggestions-container-open-z: 2;
+$autosuggest-suggestions-container-open-z: 20;
 $dropdown-content-z: 15000;
 $feedback-z: 11000;
 $feedback-button-z: 10000;
 $scrollbar-z: 0;
 $skill-code-dropdown-z: 10500;
 $spinner-z: 100;
+$ribbon-z: 10;
 
 //**
 // other variables

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -82,5 +82,6 @@
 @import 'compareDrawer';
 @import 'inputs';
 @import 'toast';
+@import 'ribbon';
 @import 'overrides';
 @import 'accessibility';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,11 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+css-box-shadow@^1.0.0-3:
+  version "1.0.0-3"
+  resolved "https://registry.yarnpkg.com/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz#9eaeb7140947bf5d649fc49a19e4bbaa5f602713"
+  integrity sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"


### PR DESCRIPTION
* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* feature: add bid list button to the favorites cards. TM-512

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Update empty saved search list text (#101)

* Add custom filter for including null language positions (#104)

* Remove Status component throughout app (#105)

* fix: change label. TM-632 (#107)

* Adjust elements to grow

* fix: allow export on edge to run

* Styles, add post to top

* Update ordering for data points on Compare page (#110)

* Remove post, add grade to bottom section

* Updates to Bid Tracker (#115)

* Add opacity to on-hold bids

* "priority" -> "pending"

* Prop to hide the delete button for standby bids

* Track favoriting loading state of individual IDs (#108)

* Track favoriting loading state of individual IDs

* Fix proptypes

* Handshake ribbon (#113)

* Re-usable Ribbon component, use Ribbon component to display if handshake has been offered on position

* Display handshake in condensed card, tests and snapshots

* Test coverage (#117)

* Test coverage for AccountDropdown, CompareDrawer, Compare

* Add tests for SetType

* Add toast notifications for favoriting actions (#114)

* Create BoxShadow component and use with various cards (#106)

* dev -> staging (#98) (#119)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Sprint 6 merge conflicts (#120)

* dev -> staging (#98)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Remove duplicates