### PR TITLE
sprint-10 -> staging (#201)

### DIFF
--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -24,7 +24,10 @@ Object.values = (obj) => Object.keys(obj).map(key => obj[key])
 // Avoid jest error: "Error: Not implemented: navigation (except hash changes)"
 global.window.location.assign = () => {};
 
-// mock sessionStorage - feature flags config
 beforeEach(() => {
+  // mock sessionStorage - feature flags config
   sessionStorage.setItem('config', JSON.stringify(config));
+
+  // mock querySelector
+  global.document.querySelector = () => ({ offsetParent: '50px', scrollIntoView: () => {} });
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "rc-steps": "^3.1.0",
     "react": "^15.6.2",
     "react-autosuggest": "^9.3.2",
-    "react-csv": "^1.1.1",
     "react-dom": "^15.6.2",
     "react-fontawesome": "^1.6.1",
     "react-helmet": "^5.2.0",
@@ -141,7 +140,8 @@
       "!src/Components/**/index.js",
       "!src/Components/StaticDevContent/*",
       "!src/actions/showStaticContent.js",
-      "!src/reducers/showStaticContent.js"
+      "!src/reducers/showStaticContent.js",
+      "!src/Components/CSV/**/*.{js,jsx}"
     ],
     "coverageReporters": [
       "text-summary",

--- a/public/config/config.json
+++ b/public/config/config.json
@@ -5,6 +5,7 @@
   "flags": {
     "bidding": true,
     "projected_vacancy": true,
-    "static_content": true
+    "static_content": true,
+    "notifications": true
   }
 }

--- a/public/config/config_dev.json
+++ b/public/config/config_dev.json
@@ -3,8 +3,9 @@
     "baseURL": "https://dev.talentmap.api.metaphasedev.com/api/v1"
   },
   "flags": {
-    "bidding": false,
+    "bidding": true,
     "projected_vacancy": true,
-    "static_content": true
+    "static_content": true,
+    "notifications": true
   }
 }

--- a/public/login.html
+++ b/public/login.html
@@ -15,16 +15,16 @@
       <a OnClick="login('admin', 'admin');">Administrator</a>
     </li>
     <li>
-      <a OnClick="login('shadtrachl', 'password');">Leah Shadtrach</a>
+      <a OnClick="login('shadtrachl', 'password');">Leah Shadtrach (CDO)</a>
     </li>
     <li>
-      <a OnClick="login('townpostj', 'password');">Jenny Townpost</a>
+      <a OnClick="login('townpostj', 'password');">Jenny Townpost (Bidder)</a>
     </li>
     <li>
-      <a OnClick="login('rehmant', 'password');">Tarek Rehman</a>
+      <a OnClick="login('rehmant', 'password');">Tarek Rehman (Bidder)</a>
     </li>
     <li>
-      <a OnClick="login('woodwardw', 'password');">Wendy Woodward</a>
+      <a OnClick="login('woodwardw', 'password');">Wendy Woodward (AO)</a>
     </li>
   </ul>
 </div>

--- a/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardContainer/__snapshots__/BidTrackerCardContainer.test.jsx.snap
@@ -87,6 +87,14 @@ exports[`BidTrackerCardContainerComponent matches snapshot when priorityExists i
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
+          },
+        ],
         "grade": "03",
         "id": 1,
         "initials": "JD",
@@ -265,6 +273,14 @@ exports[`BidTrackerCardContainerComponent matches snapshot when priorityExists i
             Object {
               "id": 4,
               "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
+            },
+          ],
+          "favorite_positions_pv": Array [
+            Object {
+              "id": 10,
+            },
+            Object {
+              "id": 20,
             },
           ],
           "grade": "03",

--- a/src/Components/BidTracker/BidTrackerCardList/__snapshots__/BidTrackerCardList.test.jsx.snap
+++ b/src/Components/BidTracker/BidTrackerCardList/__snapshots__/BidTrackerCardList.test.jsx.snap
@@ -86,6 +86,14 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
+          },
+        ],
         "grade": "03",
         "id": 1,
         "initials": "JD",
@@ -196,6 +204,14 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
+          },
+        ],
         "grade": "03",
         "id": 1,
         "initials": "JD",
@@ -304,6 +320,14 @@ exports[`BidTrackerCardListComponent matches snapshot 1`] = `
           Object {
             "id": 4,
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
+          },
+        ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
           },
         ],
         "grade": "03",

--- a/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
+++ b/src/Components/BidTracker/__snapshots__/BidTracker.test.jsx.snap
@@ -268,6 +268,14 @@ exports[`BidTrackerComponent matches snapshot 1`] = `
                 "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
               },
             ],
+            "favorite_positions_pv": Array [
+              Object {
+                "id": 10,
+              },
+              Object {
+                "id": 20,
+              },
+            ],
             "grade": "03",
             "id": 1,
             "initials": "JD",

--- a/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioCard/__snapshots__/BidderPortfolioCard.test.jsx.snap
@@ -41,6 +41,14 @@ exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
+          },
+        ],
         "grade": "03",
         "id": 1,
         "initials": "JD",
@@ -94,6 +102,14 @@ exports[`BidderPortfolioCardComponent matches snapshot 1`] = `
           Object {
             "id": 4,
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
+          },
+        ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
           },
         ],
         "grade": "03",

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.jsx
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { BIDDER_LIST } from '../../../Constants/PropTypes';
-import { scrollToTop } from '../../../utilities';
+import { scrollToId } from '../../../utilities';
 import BidderPortfolioCardList from '../BidderPortfolioCardList';
 import BidderPortfolioGridList from '../BidderPortfolioGridList';
 import PaginationWrapper from '../../PaginationWrapper/PaginationWrapper';
 import Alert from '../../Alert/Alert';
+
+const ID = 'bidder-portfolio-container';
 
 class BidderPortfolioContainer extends Component {
   constructor(props) {
@@ -13,14 +15,16 @@ class BidderPortfolioContainer extends Component {
     this.onPageChange = this.onPageChange.bind(this);
   }
   onPageChange(q) {
-    scrollToTop();
-    this.props.queryParamUpdate(q);
+    scrollToId({ el: '.bidder-portfolio-container', config: { duration: 400 } });
+    setTimeout(() => {
+      this.props.queryParamUpdate(q);
+    }, 600);
   }
   render() {
     const { bidderPortfolio, pageSize, pageNumber, showListView, showEdit } = this.props;
     const noResults = bidderPortfolio.results.length === 0;
     return (
-      <div className="usa-grid-full user-dashboard">
+      <div className="usa-grid-full user-dashboard" id={ID}>
         {
           showListView ?
             <BidderPortfolioGridList showEdit={showEdit} results={bidderPortfolio.results} />

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.test.jsx
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/BidderPortfolioContainer.test.jsx
@@ -16,7 +16,7 @@ describe('BidderPortfolioContainerComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('can call the onPageChange function', () => {
+  it('can call the onPageChange function', (done) => {
     const spy = sinon.spy();
     const wrapper = shallow(<BidderPortfolioContainer
       bidderPortfolio={bidderListObject}
@@ -25,7 +25,10 @@ describe('BidderPortfolioContainerComponent', () => {
       queryParamUpdate={spy}
     />);
     wrapper.instance().onPageChange({});
-    sinon.assert.calledOnce(spy);
+    setTimeout(() => {
+      sinon.assert.calledOnce(spy);
+      done();
+    }, 700);
   });
 
   it('matches snapshot when the all property is greater than zero', () => {

--- a/src/Components/BidderPortfolio/BidderPortfolioContainer/__snapshots__/BidderPortfolioContainer.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioContainer/__snapshots__/BidderPortfolioContainer.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`BidderPortfolioContainerComponent matches snapshot when the all property is greater than zero 1`] = `
 <div
   className="usa-grid-full user-dashboard"
+  id="bidder-portfolio-container"
 >
   <BidderPortfolioCardList
     results={
@@ -223,6 +224,7 @@ exports[`BidderPortfolioContainerComponent matches snapshot when the all propert
 exports[`BidderPortfolioContainerComponent matches snapshot when the all property is zero 1`] = `
 <div
   className="usa-grid-full user-dashboard"
+  id="bidder-portfolio-container"
 >
   <BidderPortfolioCardList
     results={Array []}

--- a/src/Components/BidderPortfolio/BidderPortfolioGridItem/__snapshots__/BidderPortfolioGridItem.test.jsx.snap
+++ b/src/Components/BidderPortfolio/BidderPortfolioGridItem/__snapshots__/BidderPortfolioGridItem.test.jsx.snap
@@ -54,6 +54,14 @@ exports[`BidderPortfolioGridItemComponent matches snapshot 1`] = `
                   "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
                 },
               ],
+              "favorite_positions_pv": Array [
+                Object {
+                  "id": 10,
+                },
+                Object {
+                  "id": 20,
+                },
+              ],
               "grade": "03",
               "id": 1,
               "initials": "JD",
@@ -108,6 +116,14 @@ exports[`BidderPortfolioGridItemComponent matches snapshot 1`] = `
               Object {
                 "id": 4,
                 "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
+              },
+            ],
+            "favorite_positions_pv": Array [
+              Object {
+                "id": 10,
+              },
+              Object {
+                "id": 20,
               },
             ],
             "grade": "03",

--- a/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
+++ b/src/Components/BidderPortfolio/ExportLink/ExportLink.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { CSVLink } from 'react-csv';
-import { get } from 'lodash';
+import { get, mapValues } from 'lodash';
+import { CSVLink } from '../../CSV';
 import { bidderPortfolioFetchDataFromLastQuery } from '../../../actions/bidderPortfolio';
 import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
 import ExportButton from '../../ExportButton';
+import { getFormattedNumCSV, spliceStringForCSV } from '../../../utilities';
 
 // Mapping columns to data fields
 const HEADERS = [
@@ -23,7 +24,8 @@ const HEADERS = [
 // Processes results before sending to the download component to allow for custom formatting.
 const processData = data => (
   data.map(entry => ({
-    ...entry,
+    ...mapValues(entry, x => !x ? '' : x), // eslint-disable-line no-confusing-arrow
+    grade: getFormattedNumCSV(entry.grade),
     // any other processing we may want to do here
   }))
 );
@@ -74,7 +76,16 @@ export class ExportLink extends Component {
     return (
       <div className="export-button-container">
         <ExportButton onClick={this.onClick} isLoading={isLoading} />
-        <CSVLink tabIndex="-1" ref={this.setCsvRef} target="_blank" filename={this.props.filename} data={data} headers={HEADERS} />
+        <CSVLink
+          transform={spliceStringForCSV}
+          tabIndex="-1"
+          ref={this.setCsvRef}
+          target="_blank"
+          filename={this.props.filename}
+          data={data}
+          headers={HEADERS}
+          uFEFF={false}
+        />
       </div>
     );
   }

--- a/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
+++ b/src/Components/BidderPortfolio/ExportLink/__snapshots__/ExportLink.test.jsx.snap
@@ -57,7 +57,8 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
-    uFEFF={true}
+    transform={[Function]}
+    uFEFF={false}
   />
 </div>
 `;

--- a/src/Components/CSV/components/Download.js
+++ b/src/Components/CSV/components/Download.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+import React from 'react';
+import {buildURI} from '../core';
+import {
+   defaultProps as commonDefaultProps,
+   propTypes as commonPropTypes} from '../metaProps';
+const defaultProps = {
+  target: '_blank'
+};
+
+/**
+ *
+ * @example ../../sample-site/csvdownload.example.md
+ */
+class CSVDownload extends React.Component {
+
+  static defaultProps = Object.assign(
+    commonDefaultProps,
+    defaultProps
+  );
+
+  static propTypes = commonPropTypes;
+
+  constructor(props) {
+    super(props);
+    this.state={};
+  }
+
+  buildURI() {
+    return buildURI(...arguments);
+  }
+
+  componentDidMount(){
+    const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace, transform} = this.props;
+    this.state.page = window.open(
+        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace, transform
+    );
+  }
+
+  getWindow() {
+    return this.state.page;
+  }
+
+  render(){
+    return (null)
+  }
+}
+
+export default CSVDownload;
+/* eslint-enable */

--- a/src/Components/CSV/components/Link.js
+++ b/src/Components/CSV/components/Link.js
@@ -1,0 +1,116 @@
+/* eslint-disable */
+import React from 'react';
+import { buildURI, toCSV } from '../core';
+import {
+  defaultProps as commonDefaultProps,
+  propTypes as commonPropTypes
+} from '../metaProps';
+
+/**
+ *
+ * @example ../../sample-site/csvlink.example.md
+ */
+class CSVLink extends React.Component {
+  static defaultProps = commonDefaultProps;
+  static propTypes = commonPropTypes;
+
+  constructor(props) {
+    super(props);
+    this.buildURI = this.buildURI.bind(this);
+    this.state = { href: '' };
+  }
+
+  componentDidMount() {
+    const {data, headers, separator, uFEFF, enclosingCharacter, transform} = this.props;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter, transform) });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { data, headers, separator, transform, uFEFF, enclosingCharacter } = nextProps;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter, transform) });
+  }
+
+  buildURI() {
+    return buildURI(...arguments);
+  }
+
+  /**
+   * In IE11 this method will trigger the file download
+   */
+  handleLegacy(event, data, headers, separator, filename, enclosingCharacter, transform) {
+    // If this browser is IE 11, it does not support the `download` attribute
+    if (window.navigator.msSaveOrOpenBlob) {
+      // Stop the click propagation
+      event.preventDefault();
+
+      let blob = new Blob([toCSV(data, headers, separator, enclosingCharacter, transform)]);
+      window.navigator.msSaveBlob(blob, filename);
+
+      return false;
+    }
+  }
+
+  handleAsyncClick(event, ...args) {
+    const done = proceed => {
+      if (proceed === false) {
+        event.preventDefault();
+        return;
+      }
+      this.handleLegacy(event, ...args);
+    };
+
+    this.props.onClick(event, done);
+  }
+
+  handleSyncClick(event, ...args) {
+    const stopEvent = this.props.onClick(event) === false;
+    if (stopEvent) {
+      event.preventDefault();
+      return;
+    }
+    this.handleLegacy(event, ...args);
+  }
+
+  handleClick(...args) {
+    return event => {
+      if (typeof this.props.onClick === 'function') {
+        return this.props.asyncOnClick
+          ? this.handleAsyncClick(event, ...args)
+          : this.handleSyncClick(event, ...args);
+      }
+      this.handleLegacy(event, ...args);
+    };
+  }
+
+  render() {
+    const {
+      data,
+      headers,
+      separator,
+      filename,
+      uFEFF,
+      children,
+      onClick,
+      asyncOnClick,
+      enclosingCharacter,
+      transform,
+      ...rest
+    } = this.props;
+
+    return (
+      <a
+        download={filename}
+        {...rest}
+        ref={link => (this.link = link)}
+        target="_self"
+        href={this.state.href}
+        onClick={this.handleClick(data, headers, separator, filename, enclosingCharacter, transform)}
+      >
+        {children}
+      </a>
+    );
+  }
+}
+
+export default CSVLink;
+/* eslint-enable */

--- a/src/Components/CSV/core.js
+++ b/src/Components/CSV/core.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/**
+ * Simple safari detection based on user agent test
+ */
+export const isSafari = () => /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+const returnVal = v => v;
+
+export const isJsons = ((array) => Array.isArray(array) && array.every(
+ row => (typeof row === 'object' && !(row instanceof Array))
+));
+
+export const isArrays = ((array) => Array.isArray(array) && array.every(
+ row => Array.isArray(row)
+));
+
+export const jsonsHeaders = ((array) => Array.from(
+ array.map(json => Object.keys(json))
+ .reduce((a, b) => new Set([...a, ...b]), [])
+));
+
+export const jsons2arrays = (jsons, headers) => {
+  headers = headers || jsonsHeaders(jsons);
+
+  // allow headers to have custom labels, defaulting to having the header data key be the label
+  let headerLabels = headers;
+  let headerKeys = headers;
+  if (isJsons(headers)) {
+    headerLabels = headers.map((header) => header.label);
+    headerKeys = headers.map((header) => header.key);
+  }
+
+  const data = jsons.map((object) => headerKeys.map((header) => getHeaderValue(header, object)));
+  return [headerLabels, ...data];
+};
+
+export const getHeaderValue = (property, obj) => {
+  const foundValue = property
+    .replace(/\[([^\]]+)]/g, ".$1")
+    .split(".")
+    .reduce(function(o, p, i, arr) {
+      // if at any point the nested keys passed do not exist, splice the array so it doesnt keep reducing
+      if (o[p] === undefined) {
+        arr.splice(1);
+      } else {
+        return o[p];
+      }
+    }, obj);
+
+  return (foundValue === undefined) ? '' : foundValue;
+}
+
+export const elementOrEmpty = (element) => element || element === 0 ? element : '';
+
+export const joiner = ((data, separator = ',', enclosingCharacter = '"', transform = returnVal) => {
+  return data
+    .filter(e => e)
+    .map(
+      row => row
+        .map((element) => elementOrEmpty(element))
+        .map(column => transform(`${enclosingCharacter}${column}${enclosingCharacter}`))
+        .join(separator)
+    )
+    .join(`\n`);
+});
+
+export const arrays2csv = ((data, headers, separator, enclosingCharacter, transform = returnVal) =>
+ joiner(headers ? [headers, ...data] : data, separator, enclosingCharacter, transform)
+);
+
+export const jsons2csv = ((data, headers, separator, enclosingCharacter, transform = returnVal) =>
+ joiner(jsons2arrays(data, headers), separator, enclosingCharacter, transform)
+);
+
+export const string2csv = ((data, headers, separator, enclosingCharacter) =>
+  (headers) ? `${headers.join(separator)}\n${data}`: data
+);
+
+export const toCSV = (data, headers, separator, enclosingCharacter, transform = returnVal) => {
+ if (isJsons(data)) return jsons2csv(data, headers, separator, enclosingCharacter, transform);
+ if (isArrays(data)) return arrays2csv(data, headers, separator, enclosingCharacter, transform);
+ if (typeof data ==='string') return string2csv(data, headers, separator);
+ throw new TypeError(`Data should be a "String", "Array of arrays" OR "Array of objects" `);
+};
+
+export const buildURI = ((data, uFEFF, headers, separator, enclosingCharacter, transform = returnVal) => {
+  const csv = toCSV(data, headers, separator, enclosingCharacter, transform);
+  const type = isSafari() ? 'application/csv' : 'text/csv';
+  const blob = new Blob([uFEFF ? '\uFEFF' : '', csv], {type});
+  const dataURI = `data:${type};charset=utf-8,${uFEFF ? '\uFEFF' : ''}${csv}`;
+
+  const URL = window.URL || window.webkitURL;
+
+  return (typeof URL.createObjectURL === 'undefined')
+    ? dataURI
+    : URL.createObjectURL(blob);
+});
+/* eslint-enable */

--- a/src/Components/CSV/index.js
+++ b/src/Components/CSV/index.js
@@ -1,0 +1,5 @@
+import Download from './components/Download';
+import Link from './components/Link';
+
+export const CSVDownload = Download;
+export const CSVLink = Link;

--- a/src/Components/CSV/metaProps.js
+++ b/src/Components/CSV/metaProps.js
@@ -1,0 +1,39 @@
+/* eslint-disable */
+import React from 'react';
+import { string, array, oneOfType, bool, func } from 'prop-types';
+
+
+export const propTypes = {
+  data: oneOfType([string, array]).isRequired,
+  headers: array,
+  target: string,
+  separator: string,
+  filename: string,
+  uFEFF: bool,
+  onClick: func,
+  asyncOnClick: bool,
+  transform: func
+};
+
+export const defaultProps = {
+  separator: ',',
+  filename: 'generatedBy_react-csv.csv',
+  uFEFF: true,
+  asyncOnClick: false,
+  transform: v => v,
+};
+
+export const PropsNotForwarded = [
+  `data`,
+  `headers`
+];
+
+// export const DownloadPropTypes = Object.assign(
+//   {},
+//   PropTypes,
+//   {
+//     : ,
+//   }
+// );
+
+/* eslint-enable */

--- a/src/Components/CSV/readme.md
+++ b/src/Components/CSV/readme.md
@@ -1,0 +1,3 @@
+Fork of react-csv
+
+Waiting for https://github.com/react-csv/react-csv/pull/155 to be approved and merged. Once done, revert to the node module and delete this folder.

--- a/src/Components/CompareList/CompareList.jsx
+++ b/src/Components/CompareList/CompareList.jsx
@@ -286,7 +286,7 @@ class CompareList extends Component {
                             <Favorite
                               hasBorder
                               refKey={c.id}
-                              compareArray={favorites.results}
+                              compareArray={favorites}
                               useButtonClass
                               refresh
                               useButtonClassSecondary

--- a/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
+++ b/src/Components/CompareList/__snapshots__/CompareList.test.jsx.snap
@@ -439,7 +439,11 @@ exports[`CompareListComponent matches snapshot 1`] = `
             </th>
             <td>
               <Connect(FavoriteContainer)
-                compareArray={Array []}
+                compareArray={
+                  Object {
+                    "results": Array [],
+                  }
+                }
                 hasBorder={true}
                 refKey={6}
                 refresh={true}
@@ -449,7 +453,11 @@ exports[`CompareListComponent matches snapshot 1`] = `
             </td>
             <td>
               <Connect(FavoriteContainer)
-                compareArray={Array []}
+                compareArray={
+                  Object {
+                    "results": Array [],
+                  }
+                }
                 hasBorder={true}
                 refKey={60}
                 refresh={true}
@@ -961,7 +969,11 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
             </th>
             <td>
               <Connect(FavoriteContainer)
-                compareArray={Array []}
+                compareArray={
+                  Object {
+                    "results": Array [],
+                  }
+                }
                 hasBorder={true}
                 refKey={6}
                 refresh={true}
@@ -971,7 +983,11 @@ exports[`CompareListComponent matches snapshot when there is an obc id 1`] = `
             </td>
             <td>
               <Connect(FavoriteContainer)
-                compareArray={Array []}
+                compareArray={
+                  Object {
+                    "results": Array [],
+                  }
+                }
                 hasBorder={true}
                 refKey={60}
                 refresh={true}

--- a/src/Components/FavoritePositions/FavoritePositions.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.jsx
@@ -1,58 +1,102 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { POSITION_SEARCH_RESULTS, BID_RESULTS } from '../../Constants/PropTypes';
+import { FAVORITE_POSITIONS_ARRAY, BID_RESULTS } from '../../Constants/PropTypes';
 import ProfileSectionTitle from '../ProfileSectionTitle';
 import Spinner from '../Spinner';
 import SelectForm from '../SelectForm';
 import { POSITION_SEARCH_SORTS } from '../../Constants/Sort';
 import HomePagePositionsList from '../HomePagePositionsList';
 import NoFavorites from '../EmptyListAlert/NoFavorites';
+import Nav from './Nav';
 
-const FavoritePositions = ({ favorites, favoritePositionsIsLoading, favoritePositionsHasErrored,
-bidList, onSortChange }) => (
-  <div className={`usa-grid-full favorite-positions-container profile-content-inner-container ${favoritePositionsIsLoading ? 'results-loading' : ''}`}>
-    <div className="usa-grid-full favorites-top-section">
-      <div className="favorites-title-container">
-        <ProfileSectionTitle title="Favorites" icon="star" />
-      </div>
-      <div className="results-dropdown results-dropdown-sort">
-        <SelectForm
-          id="sort"
-          label="Sort by:"
-          onSelectOption={onSortChange}
-          options={POSITION_SEARCH_SORTS.options}
-          disabled={favoritePositionsIsLoading}
+class FavoritePositions extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selected: 'all',
+    };
+  }
+  getPositions() {
+    const { favorites, favoritesPV } = this.props;
+    const { selected } = this.state;
+    switch (selected) {
+      case 'open':
+        return favorites;
+      case 'pv':
+        return favoritesPV;
+      default:
+        return [...favorites, ...favoritesPV];
+    }
+  }
+  render() {
+    const { favorites, favoritesPV, favoritePositionsIsLoading,
+    favoritePositionsHasErrored, bidList, onSortChange } = this.props;
+    const positions = this.getPositions();
+    return (
+      <div className={`usa-grid-full favorite-positions-container profile-content-inner-container ${favoritePositionsIsLoading ? 'results-loading' : ''}`}>
+        <div className="usa-grid-full favorites-top-section">
+          <div className="favorites-title-container">
+            <ProfileSectionTitle title="Favorites" icon="star" />
+          </div>
+        </div>
+        <Nav
+          options={[
+            { title: 'All Favorites', value: 'all', numerator: favorites.length + favoritesPV.length },
+            { title: 'Open Positions', value: 'open', numerator: favorites.length },
+            { title: 'Projected Vacancies', value: 'pv', numerator: favoritesPV.length },
+          ]}
+          onClick={selected => this.setState({ selected })}
+          selected={this.state.selected}
+          denominator={favorites.length + favoritesPV.length}
+        />
+        <div className="usa-grid-full favorites-top-section">
+          <div className="results-dropdown results-dropdown-sort">
+            <SelectForm
+              id="sort"
+              label="Sort by:"
+              onSelectOption={onSortChange}
+              options={POSITION_SEARCH_SORTS.options}
+              disabled={favoritePositionsIsLoading}
+            />
+          </div>
+        </div>
+        {
+          favoritePositionsIsLoading && !favoritePositionsHasErrored &&
+            <Spinner type="homepage-position-results" size="big" />
+        }
+        {
+          !favoritePositionsIsLoading && !favorites.length &&
+            <NoFavorites />
+        }
+        <HomePagePositionsList
+          positions={positions}
+          favorites={favorites}
+          favoritesPV={favoritesPV}
+          bidList={bidList}
+          title="favorites"
+          maxLength={300}
+          refreshFavorites
+          showBidListButton
+          useShortFavButton
+          showCompareButton
         />
       </div>
-    </div>
-    {
-      favoritePositionsIsLoading && !favoritePositionsHasErrored &&
-        <Spinner type="homepage-position-results" size="big" />
-    }
-    {
-      !favoritePositionsIsLoading && !favorites.results.length &&
-        <NoFavorites />
-    }
-    <HomePagePositionsList
-      positions={favorites.results}
-      favorites={favorites.results}
-      bidList={bidList}
-      title="favorites"
-      maxLength={300}
-      refreshFavorites
-      showBidListButton
-      useShortFavButton
-      showCompareButton
-    />
-  </div>
-);
+    );
+  }
+}
 
 FavoritePositions.propTypes = {
-  favorites: POSITION_SEARCH_RESULTS.isRequired,
+  favorites: FAVORITE_POSITIONS_ARRAY,
+  favoritesPV: FAVORITE_POSITIONS_ARRAY,
   favoritePositionsIsLoading: PropTypes.bool.isRequired,
   favoritePositionsHasErrored: PropTypes.bool.isRequired,
   bidList: BID_RESULTS.isRequired,
   onSortChange: PropTypes.func.isRequired,
+};
+
+FavoritePositions.defaultProps = {
+  favorites: [],
+  favoritesPV: [],
 };
 
 export default FavoritePositions;

--- a/src/Components/FavoritePositions/FavoritePositions.test.jsx
+++ b/src/Components/FavoritePositions/FavoritePositions.test.jsx
@@ -7,7 +7,8 @@ import bidListObject from '../../__mocks__/bidListObject';
 
 describe('FavoritePositionsComponent', () => {
   const props = {
-    favorites: resultsObject,
+    favorites: resultsObject.results,
+    favoritesPV: resultsObject.results,
     toggleFavoritePositionIsLoading: false,
     toggleFavoritePositionHasErrored: false,
     favoritePositionsIsLoading: false,
@@ -24,29 +25,39 @@ describe('FavoritePositionsComponent', () => {
     expect(wrapper).toBeDefined();
   });
 
+  it('is defined when selected === open', () => {
+    const wrapper = shallow(
+      <FavoritePositions {...props} />,
+    );
+    wrapper.setState({ selected: 'open' });
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when selected === pv', () => {
+    const wrapper = shallow(
+      <FavoritePositions {...props} />,
+    );
+    wrapper.setState({ selected: 'pv' });
+    expect(wrapper).toBeDefined();
+  });
+
   it('can receive props', () => {
     const wrapper = shallow(
       <FavoritePositions {...props} />,
     );
-    expect(wrapper.instance().props.favorites).toBe(resultsObject);
+    expect(wrapper.instance().props.favorites).toBe(props.favorites);
   });
 
   it('displays an alert if there are no positions', () => {
     const wrapper = shallow(
       <FavoritePositions
         {...props}
-        favorites={{ results: [] }}
+        favorites={[]}
+        favoritesPV={[]}
         favoritePositionsIsLoading={false}
       />,
     );
     expect(wrapper.find('NoFavorites').exists()).toBe(true);
-  });
-
-  it('renders the Spinner when loading', () => {
-    const wrapper = shallow(
-      <FavoritePositions {...props} />,
-    );
-    expect(wrapper.instance().props.favorites).toBe(resultsObject);
   });
 
   it('renders the Spinner when loading', () => {

--- a/src/Components/FavoritePositions/Nav/Nav.jsx
+++ b/src/Components/FavoritePositions/Nav/Nav.jsx
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+import NavItem from './NavItem';
+import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
+
+class Nav extends Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+    this.state = {
+      selected: props.selected || get(props, 'options[0].title'),
+    };
+  }
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selected !== this.state.selected) {
+      this.setState({ selected: nextProps.selected });
+    }
+  }
+  onClick(selected) {
+    const { onClick } = this.props;
+    this.setState({ selected }, () => onClick(selected));
+  }
+  render() {
+    const { denominator, options } = this.props;
+    return (
+      <div className="usa-grid-full portfolio-top-nav-container">
+        {options.map((m) => {
+          const isActive = m.value === this.state.selected;
+          return (
+            <NavItem
+              key={m.title}
+              title={m.title}
+              value={m.value}
+              numerator={m.numerator}
+              denominator={denominator}
+              isActive={isActive}
+              onClick={this.onClick}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+Nav.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      numerator: PropTypes.number.isRequired,
+    }),
+  ),
+  denominator: PropTypes.number.isRequired,
+  selected: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+Nav.defaultProps = {
+  options: [],
+  denominator: 1,
+  selected: '',
+  onClick: EMPTY_FUNCTION,
+};
+
+export default Nav;

--- a/src/Components/FavoritePositions/Nav/Nav.test.jsx
+++ b/src/Components/FavoritePositions/Nav/Nav.test.jsx
@@ -1,0 +1,57 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import toJSON from 'enzyme-to-json';
+import sinon from 'sinon';
+import Nav from './Nav';
+
+describe('NavComponent', () => {
+  const props = {
+    options: [
+      { title: 'Test', value: '1', numerator: 2 },
+      { title: 'Test 2', value: '2', numerator: 3 },
+    ],
+    denominator: 5,
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <Nav {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('mounts with the selection prop', () => {
+    const exp = props.options[1].title;
+    const wrapper = shallow(
+      <Nav {...props} selected={exp} />,
+    );
+    expect(wrapper.instance().state.selected).toBe(exp);
+  });
+
+  it('updates the selected state if a new selected prop is set', () => {
+    const exp = 'test';
+    const wrapper = shallow(
+      <Nav {...props} />,
+    );
+    wrapper.setProps({ ...props, selected: exp });
+    expect(wrapper.instance().state.selected).toBe(exp);
+  });
+
+  it('sets state and calls the onClick prop when instance.onClick is called', () => {
+    const exp = 'test';
+    const spy = sinon.spy();
+    const wrapper = shallow(
+      <Nav {...props} onClick={spy} />,
+    );
+    wrapper.instance().onClick(exp);
+    sinon.assert.calledOnce(spy);
+    expect(wrapper.instance().state.selected).toBe(exp);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(
+      <Nav {...props} />,
+    );
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+});

--- a/src/Components/FavoritePositions/Nav/NavItem.jsx
+++ b/src/Components/FavoritePositions/Nav/NavItem.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { EMPTY_FUNCTION } from '../../../Constants/PropTypes';
+
+export const NavItem = ({ title, value, numerator, denominator, isActive, onClick }) => {
+  // numerator can be a zero, but not null or undefined
+  const numeratorIsNotUndefinedOrNull = numerator !== null && numerator !== undefined;
+  const showFraction = numeratorIsNotUndefinedOrNull && denominator;
+  return (
+    <div className={`usa-grid-full bidder-portfolio-navigation-item ${isActive ? 'is-underlined' : 'is-not-underlined'}`}>
+      <button className="unstyled-button" onClick={() => onClick(value)}>
+        {title} { showFraction ? <span className="navigation-item-fraction">({numerator}/{denominator})</span> : null }
+      </button>
+    </div>
+  );
+};
+
+NavItem.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  numerator: PropTypes.number,
+  denominator: PropTypes.number,
+  isActive: PropTypes.bool,
+  onClick: PropTypes.func,
+};
+
+NavItem.defaultProps = {
+  numerator: undefined,
+  denominator: undefined,
+  isActive: false,
+  onClick: EMPTY_FUNCTION,
+};
+
+export default NavItem;

--- a/src/Components/FavoritePositions/Nav/NavItem.test.jsx
+++ b/src/Components/FavoritePositions/Nav/NavItem.test.jsx
@@ -1,0 +1,34 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import NavItem from './NavItem';
+
+describe('NavItemComponent', () => {
+  const props = {
+    title: 'test',
+    value: 't',
+    numerator: 5,
+    denominator: 10,
+    isActive: false,
+  };
+
+  it('is defined', () => {
+    const wrapper = shallow(
+      <NavItem {...props} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when isActive === true', () => {
+    const wrapper = shallow(
+      <NavItem {...props} isActive />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when when numerator === null', () => {
+    const wrapper = shallow(
+      <NavItem {...props} numerator={null} />,
+    );
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Components/FavoritePositions/Nav/__snapshots__/Nav.test.jsx.snap
+++ b/src/Components/FavoritePositions/Nav/__snapshots__/Nav.test.jsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavComponent matches snapshot 1`] = `
+<div
+  className="usa-grid-full portfolio-top-nav-container"
+>
+  <Component
+    denominator={5}
+    isActive={false}
+    numerator={2}
+    onClick={[Function]}
+    title="Test"
+    value="1"
+  />
+  <Component
+    denominator={5}
+    isActive={false}
+    numerator={3}
+    onClick={[Function]}
+    title="Test 2"
+    value="2"
+  />
+</div>
+`;

--- a/src/Components/FavoritePositions/Nav/index.js
+++ b/src/Components/FavoritePositions/Nav/index.js
@@ -1,0 +1,1 @@
+export { default } from './Nav';

--- a/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
+++ b/src/Components/FavoritePositions/__snapshots__/FavoritePositions.test.jsx.snap
@@ -15,6 +15,34 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
         title="Favorites"
       />
     </div>
+  </div>
+  <Nav
+    denominator={4}
+    onClick={[Function]}
+    options={
+      Array [
+        Object {
+          "numerator": 4,
+          "title": "All Favorites",
+          "value": "all",
+        },
+        Object {
+          "numerator": 2,
+          "title": "Open Positions",
+          "value": "open",
+        },
+        Object {
+          "numerator": 2,
+          "title": "Projected Vacancies",
+          "value": "pv",
+        },
+      ]
+    }
+    selected="all"
+  />
+  <div
+    className="usa-grid-full favorites-top-section"
+  >
     <div
       className="results-dropdown results-dropdown-sort"
     >
@@ -386,10 +414,348 @@ exports[`FavoritePositionsComponent matches snapshot 1`] = `
         },
       ]
     }
+    favoritesPV={
+      Array [
+        Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+              "id": 6,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 2,
+            },
+          ],
+          "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+          "classifications": Array [],
+          "create_date": "2006-09-20T00:00:00Z",
+          "current_assignment": Object {
+            "estimated_end_date": "2020-03-13T15:51:11.478084Z",
+            "start_date": "2018-03-13T15:51:11.478084Z",
+            "status": "active",
+            "tour_of_duty": "2 YRS (2 R & R)",
+            "user": "John Doe",
+          },
+          "description": Object {
+            "content": "The Office Management Specialist (OMS) for the Deputy Chief of Mission (DCM) provides office management services in this Mission of six agencies, 387 American and Locally Employed Staff (LES) positions, and 279 guard force contractors.  The OMS manages Executive Office operations and positionstains the DCM’s calendar in support of overall Mission goals and objectives.  The OMS (DCM) drafts routine correspondence, memoranda and cables as appropriate and ensures documents are cleared and delivered in a timely fashion. The OMS serves as back up to the Ambassador’s OMS.  POCs areSandra McInturff, DCM OMS, McInturffSL@state.gov, 231-77-677-7000, ext. 7452; Samue Watson, DCM, WatsonSR@state.gov, 231-77-677-7000, ext. 7452. Please submit lobbying documents to the 360 Community Lobbying Center http://appcenter.state.sbu/CLC. (Revised 1/2017)
+
+",
+            "date_created": "2018-03-08T18:00:33.241370Z",
+            "date_updated": "2018-03-13T15:55:00.018644Z",
+            "id": 90,
+            "is_editable_by_user": false,
+            "last_editing_user": null,
+            "point_of_contact": null,
+            "website": null,
+          },
+          "effective_date": "2012-10-22T00:00:00Z",
+          "grade": "06",
+          "id": 6,
+          "is_highlighted": false,
+          "is_overseas": true,
+          "languages": Array [],
+          "latest_bidcycle": Object {
+            "active": true,
+            "cycle_deadline_date": "2018-04-13T15:51:10.980554Z",
+            "cycle_end_date": "2018-06-13T15:51:10.980554Z",
+            "cycle_start_date": "2017-12-13T15:51:10.980554Z",
+            "id": 1,
+            "name": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+          },
+          "organization": "(MONROVIA) MONROVIA LIBERIA",
+          "position_number": "10034001",
+          "post": Object {
+            "code": "LI6000000",
+            "cost_of_living_adjustment": 30,
+            "danger_pay": 0,
+            "differential_rate": 30,
+            "has_consumable_allowance": true,
+            "has_service_needs_differential": true,
+            "id": 160,
+            "location": Object {
+              "city": "Freetown",
+              "code": "00A",
+              "country": "Sierra Leone",
+              "id": 103,
+              "state": "",
+            },
+            "obc_id": null,
+            "rest_relaxation_point": "Paris",
+            "tour_of_duty": "2 YRS (2 R & R)",
+          },
+          "posted_date": "2012-10-22T00:00:00Z",
+          "representation": "[10034001] OMS (DCM) (Monrovia, Liberia)",
+          "skill": "OFFICE MANAGEMENT (9017)",
+          "status": null,
+          "status_code": null,
+          "title": "OMS (DCM)",
+          "tour_of_duty": null,
+          "update_date": "2017-06-08T00:00:00Z",
+        },
+        Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+              "id": 60,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 0,
+            },
+          ],
+          "bureau": "(WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS",
+          "classifications": Array [],
+          "create_date": "2006-09-20T00:00:00Z",
+          "current_assignment": Object {
+            "estimated_end_date": "2020-03-13T15:51:13.126727Z",
+            "start_date": "2018-03-13T15:51:13.126727Z",
+            "status": "active",
+            "tour_of_duty": "2 YRS (2 R & R)",
+            "user": "John Doe",
+          },
+          "description": Object {
+            "content": "(updated August 2012) The incumbent serves as one of four Assistant Regional Security Officers (ARSO) in the Regional Security Office in a two year assignment with a rotating management portfolio that provides generous exposure to all aspects of Diplomatic Security’s overseas programs. RSO Port-au-Prince currently consists of a 6 member Marine Security Guard Detachment, 750+direct hire Mission guard force, 17 direct-hire Bodyguards, 2 FSN Investigators, 6 member Surveillance Detection Team, a 2-person Residential Security Unit, and one Office Management Specialist.  The incumbent has direct supervisory responsibilities.  The incumbent is expected to manage the Marine Security Guard program, Mission residential and physical security programs, operational and administrative oversight of the direct hire Mission guard force, and complex budget issues. The incumbent also coordinates security for large-scale Mission events and visiting high ranking USG officials and conducts personnel, terrorist, criminal, and counterintelligence investigations as required. Point of Contact is RSO Jeffrey M. Roberts.",
+            "date_created": "2018-03-08T18:00:32.971745Z",
+            "date_updated": "2018-03-13T15:54:59.677323Z",
+            "id": 26,
+            "is_editable_by_user": false,
+            "last_editing_user": null,
+            "point_of_contact": null,
+            "website": null,
+          },
+          "effective_date": "2016-10-02T00:00:00Z",
+          "grade": "04",
+          "id": 60,
+          "is_highlighted": false,
+          "is_overseas": true,
+          "languages": Array [
+            Object {
+              "id": 1,
+              "language": "French (FR)",
+              "reading_proficiency": "2",
+              "representation": "French (FR) 2/2",
+              "spoken_proficiency": "2",
+            },
+            Object {
+              "id": 20,
+              "language": "Haitian Creole (HC)",
+              "reading_proficiency": "0",
+              "representation": "Haitian Creole (HC) 0/0",
+              "spoken_proficiency": "0",
+            },
+          ],
+          "latest_bidcycle": Object {
+            "active": true,
+            "cycle_deadline_date": "2018-04-13T15:51:10.980554Z",
+            "cycle_end_date": "2018-06-13T15:51:10.980554Z",
+            "cycle_start_date": "2017-12-13T15:51:10.980554Z",
+            "id": 1,
+            "name": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+          },
+          "organization": "(PORT AU PRIN) PORT AU PRINCE HAITI",
+          "position_number": "56082000",
+          "post": Object {
+            "code": "HA7000000",
+            "cost_of_living_adjustment": 15,
+            "danger_pay": 15,
+            "differential_rate": 20,
+            "has_consumable_allowance": true,
+            "has_service_needs_differential": true,
+            "id": 110,
+            "location": Object {
+              "city": "Chicago",
+              "code": "101",
+              "country": "United States",
+              "id": 7,
+              "state": "IL",
+            },
+            "obc_id": null,
+            "rest_relaxation_point": "Miami",
+            "tour_of_duty": "2 YRS (2 R & R)",
+          },
+          "posted_date": "2016-10-02T00:00:00Z",
+          "representation": "[56082000] SPECIAL AGENT (Port-Au-Prince, Haiti)",
+          "skill": "SECURITY (2501)",
+          "status": null,
+          "status_code": null,
+          "title": "SPECIAL AGENT",
+          "tour_of_duty": null,
+          "update_date": "2017-06-08T00:00:00Z",
+        },
+      ]
+    }
     isLoading={false}
     maxLength={300}
     positions={
       Array [
+        Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+              "id": 6,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 2,
+            },
+          ],
+          "bureau": "(AF) BUREAU OF AFRICAN AFFAIRS",
+          "classifications": Array [],
+          "create_date": "2006-09-20T00:00:00Z",
+          "current_assignment": Object {
+            "estimated_end_date": "2020-03-13T15:51:11.478084Z",
+            "start_date": "2018-03-13T15:51:11.478084Z",
+            "status": "active",
+            "tour_of_duty": "2 YRS (2 R & R)",
+            "user": "John Doe",
+          },
+          "description": Object {
+            "content": "The Office Management Specialist (OMS) for the Deputy Chief of Mission (DCM) provides office management services in this Mission of six agencies, 387 American and Locally Employed Staff (LES) positions, and 279 guard force contractors.  The OMS manages Executive Office operations and positionstains the DCM’s calendar in support of overall Mission goals and objectives.  The OMS (DCM) drafts routine correspondence, memoranda and cables as appropriate and ensures documents are cleared and delivered in a timely fashion. The OMS serves as back up to the Ambassador’s OMS.  POCs areSandra McInturff, DCM OMS, McInturffSL@state.gov, 231-77-677-7000, ext. 7452; Samue Watson, DCM, WatsonSR@state.gov, 231-77-677-7000, ext. 7452. Please submit lobbying documents to the 360 Community Lobbying Center http://appcenter.state.sbu/CLC. (Revised 1/2017)
+
+",
+            "date_created": "2018-03-08T18:00:33.241370Z",
+            "date_updated": "2018-03-13T15:55:00.018644Z",
+            "id": 90,
+            "is_editable_by_user": false,
+            "last_editing_user": null,
+            "point_of_contact": null,
+            "website": null,
+          },
+          "effective_date": "2012-10-22T00:00:00Z",
+          "grade": "06",
+          "id": 6,
+          "is_highlighted": false,
+          "is_overseas": true,
+          "languages": Array [],
+          "latest_bidcycle": Object {
+            "active": true,
+            "cycle_deadline_date": "2018-04-13T15:51:10.980554Z",
+            "cycle_end_date": "2018-06-13T15:51:10.980554Z",
+            "cycle_start_date": "2017-12-13T15:51:10.980554Z",
+            "id": 1,
+            "name": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+          },
+          "organization": "(MONROVIA) MONROVIA LIBERIA",
+          "position_number": "10034001",
+          "post": Object {
+            "code": "LI6000000",
+            "cost_of_living_adjustment": 30,
+            "danger_pay": 0,
+            "differential_rate": 30,
+            "has_consumable_allowance": true,
+            "has_service_needs_differential": true,
+            "id": 160,
+            "location": Object {
+              "city": "Freetown",
+              "code": "00A",
+              "country": "Sierra Leone",
+              "id": 103,
+              "state": "",
+            },
+            "obc_id": null,
+            "rest_relaxation_point": "Paris",
+            "tour_of_duty": "2 YRS (2 R & R)",
+          },
+          "posted_date": "2012-10-22T00:00:00Z",
+          "representation": "[10034001] OMS (DCM) (Monrovia, Liberia)",
+          "skill": "OFFICE MANAGEMENT (9017)",
+          "status": null,
+          "status_code": null,
+          "title": "OMS (DCM)",
+          "tour_of_duty": null,
+          "update_date": "2017-06-08T00:00:00Z",
+        },
+        Object {
+          "bid_statistics": Array [
+            Object {
+              "at_skill": 0,
+              "bidcycle": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+              "id": 60,
+              "in_grade": 0,
+              "in_grade_at_skill": 0,
+              "total_bids": 0,
+            },
+          ],
+          "bureau": "(WHA) BUREAU OF WESTERN HEMISPHERIC AFFAIRS",
+          "classifications": Array [],
+          "create_date": "2006-09-20T00:00:00Z",
+          "current_assignment": Object {
+            "estimated_end_date": "2020-03-13T15:51:13.126727Z",
+            "start_date": "2018-03-13T15:51:13.126727Z",
+            "status": "active",
+            "tour_of_duty": "2 YRS (2 R & R)",
+            "user": "John Doe",
+          },
+          "description": Object {
+            "content": "(updated August 2012) The incumbent serves as one of four Assistant Regional Security Officers (ARSO) in the Regional Security Office in a two year assignment with a rotating management portfolio that provides generous exposure to all aspects of Diplomatic Security’s overseas programs. RSO Port-au-Prince currently consists of a 6 member Marine Security Guard Detachment, 750+direct hire Mission guard force, 17 direct-hire Bodyguards, 2 FSN Investigators, 6 member Surveillance Detection Team, a 2-person Residential Security Unit, and one Office Management Specialist.  The incumbent has direct supervisory responsibilities.  The incumbent is expected to manage the Marine Security Guard program, Mission residential and physical security programs, operational and administrative oversight of the direct hire Mission guard force, and complex budget issues. The incumbent also coordinates security for large-scale Mission events and visiting high ranking USG officials and conducts personnel, terrorist, criminal, and counterintelligence investigations as required. Point of Contact is RSO Jeffrey M. Roberts.",
+            "date_created": "2018-03-08T18:00:32.971745Z",
+            "date_updated": "2018-03-13T15:54:59.677323Z",
+            "id": 26,
+            "is_editable_by_user": false,
+            "last_editing_user": null,
+            "point_of_contact": null,
+            "website": null,
+          },
+          "effective_date": "2016-10-02T00:00:00Z",
+          "grade": "04",
+          "id": 60,
+          "is_highlighted": false,
+          "is_overseas": true,
+          "languages": Array [
+            Object {
+              "id": 1,
+              "language": "French (FR)",
+              "reading_proficiency": "2",
+              "representation": "French (FR) 2/2",
+              "spoken_proficiency": "2",
+            },
+            Object {
+              "id": 20,
+              "language": "Haitian Creole (HC)",
+              "reading_proficiency": "0",
+              "representation": "Haitian Creole (HC) 0/0",
+              "spoken_proficiency": "0",
+            },
+          ],
+          "latest_bidcycle": Object {
+            "active": true,
+            "cycle_deadline_date": "2018-04-13T15:51:10.980554Z",
+            "cycle_end_date": "2018-06-13T15:51:10.980554Z",
+            "cycle_start_date": "2017-12-13T15:51:10.980554Z",
+            "id": 1,
+            "name": "Demo BidCycle 2018-03-13 15:51:10.980576+00:00",
+          },
+          "organization": "(PORT AU PRIN) PORT AU PRINCE HAITI",
+          "position_number": "56082000",
+          "post": Object {
+            "code": "HA7000000",
+            "cost_of_living_adjustment": 15,
+            "danger_pay": 15,
+            "differential_rate": 20,
+            "has_consumable_allowance": true,
+            "has_service_needs_differential": true,
+            "id": 110,
+            "location": Object {
+              "city": "Chicago",
+              "code": "101",
+              "country": "United States",
+              "id": 7,
+              "state": "IL",
+            },
+            "obc_id": null,
+            "rest_relaxation_point": "Miami",
+            "tour_of_duty": "2 YRS (2 R & R)",
+          },
+          "posted_date": "2016-10-02T00:00:00Z",
+          "representation": "[56082000] SPECIAL AGENT (Port-Au-Prince, Haiti)",
+          "skill": "SECURITY (2501)",
+          "status": null,
+          "status_code": null,
+          "title": "SPECIAL AGENT",
+          "tour_of_duty": null,
+          "update_date": "2017-06-08T00:00:00Z",
+        },
         Object {
           "bid_statistics": Array [
             Object {

--- a/src/Components/Header/DesktopNav/DesktopNav.jsx
+++ b/src/Components/Header/DesktopNav/DesktopNav.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
+import { Flag } from 'flag';
 import { USER_PROFILE } from '../../../Constants/PropTypes';
 import Notifications from '../Notifications';
 import GlossaryIcon from '../GlossaryIcon';
@@ -55,7 +56,9 @@ const DesktopNav = ({
           {
             isLoggedIn &&
               <span>
-                <Notifications />
+                <Flag name="flags.notifications">
+                  <Notifications />
+                </Flag>
                 <GlossaryIcon />
               </span>
           }

--- a/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
+++ b/src/Components/Header/DesktopNav/__snapshots__/DesktopNav.test.jsx.snap
@@ -78,6 +78,14 @@ exports[`DesktopNav matches snapshot when logged in 1`] = `
                   "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
                 },
               ],
+              "favorite_positions_pv": Array [
+                Object {
+                  "id": 10,
+                },
+                Object {
+                  "id": 20,
+                },
+              ],
               "grade": "03",
               "id": 1,
               "initials": "JD",
@@ -119,7 +127,11 @@ exports[`DesktopNav matches snapshot when logged in 1`] = `
         className="header-nav-link"
       >
         <span>
-          <Connect(withRouter(Notifications)) />
+          <Flag
+            name="flags.notifications"
+          >
+            <Connect(withRouter(Notifications)) />
+          </Flag>
           <Connect(GlossaryIcon) />
         </span>
       </div>

--- a/src/Components/HomePagePositionsList/HomePagePositionsList.jsx
+++ b/src/Components/HomePagePositionsList/HomePagePositionsList.jsx
@@ -6,6 +6,7 @@ import { POSITION_DETAILS_ARRAY, FAVORITE_POSITIONS_ARRAY, BID_RESULTS, HOME_PAG
 const propTypes = {
   positions: POSITION_DETAILS_ARRAY,
   favorites: FAVORITE_POSITIONS_ARRAY,
+  favoritesPV: FAVORITE_POSITIONS_ARRAY,
   isLoading: PropTypes.bool,
   bidList: BID_RESULTS.isRequired,
   type: HOME_PAGE_CARD_TYPE,
@@ -19,6 +20,7 @@ const propTypes = {
 const defaultProps = {
   positions: [],
   favorites: [],
+  favoritesPV: [],
   isLoading: false,
   type: 'default',
   refreshFavorites: false,
@@ -27,14 +29,15 @@ const defaultProps = {
   showCompareButton: false,
 };
 
-const HomePagePositionsList = ({ positions, favorites, isLoading, bidList, type,
+const HomePagePositionsList = ({ positions, favorites, favoritesPV, isLoading, bidList, type,
 refreshFavorites, title, showBidListButton, useShortFavButton, showCompareButton }) => (
   <div className={`condensed-card-highlighted ${isLoading ? 'results-loading' : ''}`}>
     <div className="usa-grid-full condensed-card-grid">
       {positions.map(p => (
-        <div key={`${title}-row-${p.id}`} className="usa-width-one-third condensed-card">
+        <div key={`${title}-row-${p.id}-${p.isPV}`} className="usa-width-one-third condensed-card">
           <ResultsCondensedCard
             favorites={favorites}
+            favoritesPV={favoritesPV}
             position={p}
             bidList={bidList}
             type={type}
@@ -42,6 +45,7 @@ refreshFavorites, title, showBidListButton, useShortFavButton, showCompareButton
             showBidListButton={showBidListButton}
             useShortFavButton={useShortFavButton}
             showCompareButton={showCompareButton}
+            isProjectedVacancy={p.isPV}
           />
         </div>
       ))}

--- a/src/Components/HomePagePositionsList/__snapshots__/HomePagePositionsList.test.jsx.snap
+++ b/src/Components/HomePagePositionsList/__snapshots__/HomePagePositionsList.test.jsx.snap
@@ -157,6 +157,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={
@@ -395,6 +396,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={
@@ -633,6 +635,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={
@@ -871,6 +874,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={
@@ -1109,6 +1113,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={
@@ -1347,6 +1352,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={
@@ -1585,6 +1591,7 @@ exports[`HomePagePositionsList displays two rows 1`] = `
           ]
         }
         favorites={Array []}
+        favoritesPV={Array []}
         isProjectedVacancy={false}
         isRecentlyAvailable={false}
         position={

--- a/src/Components/HomePagePositionsSection/__snapshots__/HomePagePositionsSection.test.jsx.snap
+++ b/src/Components/HomePagePositionsSection/__snapshots__/HomePagePositionsSection.test.jsx.snap
@@ -170,6 +170,7 @@ exports[`HomePagePositionsSection matches snapshot 1`] = `
       ]
     }
     favorites={Array []}
+    favoritesPV={Array []}
     isLoading={false}
     positions={
       Array [

--- a/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
+++ b/src/Components/PositionDetailsItem/PositionDetailsItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { Flag } from 'flag';
+import { COMMON_PROPERTIES } from '../../Constants/EndpointParams';
 import LanguageList from '../../Components/LanguageList/LanguageList';
 import CondensedCardDataPoint from '../CondensedCardData/CondensedCardDataPoint';
 import OBCUrl from '../OBCUrl';
@@ -33,6 +34,7 @@ import {
   NO_POST_DIFFERENTIAL,
   NO_DANGER_PAY,
   NO_USER_LISTED,
+  NO_UPDATE_DATE,
 } from '../../Constants/SystemMessages';
 
 export const renderHandshake = stats => (
@@ -76,6 +78,15 @@ const PositionDetailsItem = (props) => {
 
   const incumbent = propOrDefault(details, 'current_assignment.user', NO_USER_LISTED);
 
+  const getPostedDate = () => {
+    const posted = get(details, COMMON_PROPERTIES.posted);
+    if (posted) {
+      return formatDate(posted);
+    }
+    return NO_UPDATE_DATE;
+  };
+  const postedDate = getPostedDate();
+
   const stats = getBidStatisticsObject(details.bid_statistics);
   return (
     <div className="usa-grid-full padded-main-content position-details-outer-container">
@@ -102,6 +113,7 @@ const PositionDetailsItem = (props) => {
             <CondensedCardDataPoint title="Danger pay" content={getFormattedObcData(dangerPay)} />
             <CondensedCardDataPoint title="TED" content={formattedTourEndDate} />
             <CondensedCardDataPoint title="Incumbent" content={incumbent} />
+            <CondensedCardDataPoint title="Posted" content={postedDate} />
           </div>
         </div>
         <div className="usa-width-one-third position-details-contact-container">

--- a/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
+++ b/src/Components/PositionDetailsItem/__snapshots__/PositionDetailsItem.test.jsx.snap
@@ -111,6 +111,11 @@ exports[`PositionDetailsItem matches snapshot 1`] = `
           hasFixedTitleWidth={false}
           title="Incumbent"
         />
+        <CondensedCardDataPoint
+          content="Unknown"
+          hasFixedTitleWidth={false}
+          title="Posted"
+        />
       </div>
     </div>
     <div
@@ -334,6 +339,11 @@ exports[`PositionDetailsItem matches snapshot when there is an obc id 1`] = `
           hasFixedTitleWidth={false}
           title="Incumbent"
         />
+        <CondensedCardDataPoint
+          content="Unknown"
+          hasFixedTitleWidth={false}
+          title="Posted"
+        />
       </div>
     </div>
     <div
@@ -535,6 +545,11 @@ exports[`PositionDetailsItem matches snapshot when various data is missing from 
           content="None listed"
           hasFixedTitleWidth={false}
           title="Incumbent"
+        />
+        <CondensedCardDataPoint
+          content="Unknown"
+          hasFixedTitleWidth={false}
+          title="Posted"
         />
       </div>
     </div>

--- a/src/Components/ProfileDashboard/ProfileDashboard.jsx
+++ b/src/Components/ProfileDashboard/ProfileDashboard.jsx
@@ -57,9 +57,11 @@ const ProfileDashboard = ({
                         columns={columns[1]}
                         className={'user-dashboard-section-container user-dashboard-column-2'}
                       >
-                        <BoxShadow className="usa-width-one-whole user-dashboard-section notifications-section">
-                          <Notifications notifications={notifications} />
-                        </BoxShadow>
+                        <Flag name="flags.notifications">
+                          <BoxShadow className="usa-width-one-whole user-dashboard-section notifications-section">
+                            <Notifications notifications={notifications} />
+                          </BoxShadow>
+                        </Flag>
                         <BoxShadow className="usa-width-one-whole user-dashboard-section favorites-section">
                           <SavedSearches />
                         </BoxShadow>

--- a/src/Components/ProfileDashboard/UserProfile/__snapshots__/UserProfile.test.jsx.snap
+++ b/src/Components/ProfileDashboard/UserProfile/__snapshots__/UserProfile.test.jsx.snap
@@ -33,6 +33,14 @@ exports[`UserProfileComponent matches snapshot 1`] = `
             "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
           },
         ],
+        "favorite_positions_pv": Array [
+          Object {
+            "id": 10,
+          },
+          Object {
+            "id": 20,
+          },
+        ],
         "grade": "03",
         "id": 1,
         "initials": "JD",
@@ -122,6 +130,14 @@ exports[`UserProfileComponent matches snapshot 1`] = `
             Object {
               "id": 4,
               "representation": "[00180000] OMS (DCM) (Addis Ababa, Ethiopia)",
+            },
+          ],
+          "favorite_positions_pv": Array [
+            Object {
+              "id": 10,
+            },
+            Object {
+              "id": 20,
             },
           ],
           "grade": "03",

--- a/src/Components/ResultsCard/ResultsCard.jsx
+++ b/src/Components/ResultsCard/ResultsCard.jsx
@@ -76,6 +76,7 @@ class ResultsCard extends Component {
       id,
       result,
       favorites,
+      favoritesPV,
     } = this.props;
     const { isProjectedVacancy } = this.context;
 
@@ -122,11 +123,12 @@ class ResultsCard extends Component {
     ];
 
     options.favorite = {
-      compareArray: favorites,
+      compareArray: isProjectedVacancy ? favoritesPV : favorites,
       refKey: result.id,
       hasBorder: true,
       useButtonClass: true,
       useLongText: true,
+      isPV: isProjectedVacancy,
     };
 
     options.compare = {
@@ -193,16 +195,13 @@ class ResultsCard extends Component {
               }
               />
               <Row className="footer results-card-padded-section" fluid>
-                {
-                !isProjectedVacancy &&
                 <Column columns="6" as="section">
                   {
                     !!favorites &&
                       <Favorite {...options.favorite} />
                   }
-                  <CompareCheck {...options.compare} />
+                  {!isProjectedVacancy && <CompareCheck {...options.compare} />}
                 </Column>
-              }
                 <Column columns="6" as="section">
                   <div>
                     <DefinitionList items={sections[2]} />
@@ -231,10 +230,12 @@ ResultsCard.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   result: POSITION_DETAILS.isRequired,
   favorites: FAVORITE_POSITIONS_ARRAY,
+  favoritesPV: FAVORITE_POSITIONS_ARRAY,
 };
 
 ResultsCard.defaultProps = {
   favorites: [],
+  favoritesPV: [],
 };
 
 export default ResultsCard;

--- a/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
+++ b/src/Components/ResultsCondensedCard/ResultsCondensedCard.jsx
@@ -10,6 +10,7 @@ const ResultsCondensedCard = (
   {
     position,
     favorites,
+    favoritesPV,
     bidList,
     type,
     refreshFavorites,
@@ -30,12 +31,14 @@ const ResultsCondensedCard = (
       <ResultsCondensedCardBottom
         position={position}
         favorites={favorites}
+        favoritesPV={favoritesPV}
         bidList={bidList}
         refreshFavorites={refreshFavorites}
         showBidListButton={showBidListButton && !isProjectedVacancy}
         showBidCount={!isProjectedVacancy}
         useShortFavButton={useShortFavButton}
         showCompareButton={showCompareButton}
+        isProjectedVacancy={isProjectedVacancy}
       />
       <ResultsCondensedCardFooter
         position={position}
@@ -46,6 +49,7 @@ const ResultsCondensedCard = (
 ResultsCondensedCard.propTypes = {
   position: POSITION_DETAILS.isRequired,
   favorites: FAVORITE_POSITIONS_ARRAY,
+  favoritesPV: FAVORITE_POSITIONS_ARRAY,
   bidList: BID_RESULTS.isRequired,
   type: HOME_PAGE_CARD_TYPE.isRequired,
   refreshFavorites: PropTypes.bool,
@@ -58,6 +62,7 @@ ResultsCondensedCard.propTypes = {
 
 ResultsCondensedCard.defaultProps = {
   favorites: [],
+  favoritesPV: [],
   refreshFavorites: false,
   showBidListButton: false,
   isProjectedVacancy: false,

--- a/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
+++ b/src/Components/ResultsCondensedCard/__snapshots__/ResultsCondensedCard.test.jsx.snap
@@ -244,6 +244,8 @@ exports[`ResultsCondensedCardComponent matches snapshot 1`] = `
       ]
     }
     favorites={Array []}
+    favoritesPV={Array []}
+    isProjectedVacancy={false}
     position={
       Object {
         "bid_statistics": Array [

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.jsx
@@ -38,9 +38,11 @@ class ResultsCondensedCardBottom extends Component {
   render() {
     const { position,
         favorites,
+        favoritesPV,
         refreshFavorites,
         useShortFavButton,
         showCompareButton,
+        isProjectedVacancy,
       } = this.props;
     return (
       <div className="condensed-card-bottom-container">
@@ -56,7 +58,8 @@ class ResultsCondensedCardBottom extends Component {
               hideText={useShortFavButton}
               hasBorder
               refKey={position.id}
-              compareArray={favorites}
+              isPV={position.isPV}
+              compareArray={position.isPV ? favoritesPV : favorites}
               useButtonClass={!useShortFavButton}
               useButtonClassSecondary={useShortFavButton}
               refresh={refreshFavorites}
@@ -66,7 +69,7 @@ class ResultsCondensedCardBottom extends Component {
               render={this.renderBidListButton}
             />
             {
-              showCompareButton &&
+              showCompareButton && !isProjectedVacancy &&
               <CompareCheck as="div" refKey={position.position_number} />
             }
           </div>
@@ -79,11 +82,13 @@ class ResultsCondensedCardBottom extends Component {
 ResultsCondensedCardBottom.propTypes = {
   position: POSITION_DETAILS.isRequired,
   favorites: FAVORITE_POSITIONS_ARRAY.isRequired,
+  favoritesPV: FAVORITE_POSITIONS_ARRAY.isRequired,
   refreshFavorites: PropTypes.bool,
   showBidListButton: PropTypes.bool,
   showBidCount: PropTypes.bool,
   useShortFavButton: PropTypes.bool,
   showCompareButton: PropTypes.bool,
+  isProjectedVacancy: PropTypes.bool,
 };
 
 ResultsCondensedCardBottom.defaultProps = {
@@ -93,6 +98,7 @@ ResultsCondensedCardBottom.defaultProps = {
   showBidCount: true,
   useShortFavButton: false,
   showCompareButton: false,
+  isProjectedVacancy: false,
 };
 
 export default ResultsCondensedCardBottom;

--- a/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
+++ b/src/Components/ResultsCondensedCardBottom/ResultsCondensedCardBottom.test.jsx
@@ -9,12 +9,14 @@ import { bidderUserObject } from '../../__mocks__/userObject';
 describe('ResultsCondensedCardBottomComponent', () => {
   const type = 'default';
   const favorites = bidderUserObject.favorite_positions;
+  const favoritesPV = bidderUserObject.favorite_positions_pv;
   it('is defined', () => {
     const wrapper = shallow(
       <ResultsCondensedCardBottom
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
       />,
     );
     expect(wrapper).toBeDefined();
@@ -26,6 +28,7 @@ describe('ResultsCondensedCardBottomComponent', () => {
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
       />,
     );
     expect(wrapper.instance().props.type).toBe(type);
@@ -37,6 +40,7 @@ describe('ResultsCondensedCardBottomComponent', () => {
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
         showBidCount={false}
       />,
     );
@@ -49,6 +53,7 @@ describe('ResultsCondensedCardBottomComponent', () => {
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
         showBidCount
       />,
     );
@@ -61,6 +66,7 @@ describe('ResultsCondensedCardBottomComponent', () => {
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
         showBidListButton
       />,
     );
@@ -73,6 +79,7 @@ describe('ResultsCondensedCardBottomComponent', () => {
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
       />,
     );
     expect(toJSON(wrapper)).toMatchSnapshot();
@@ -84,6 +91,7 @@ describe('ResultsCondensedCardBottomComponent', () => {
         position={resultsObject.results[0]}
         bidList={bidListObject.results}
         favorites={favorites}
+        favoritesPV={favoritesPV}
         showBidListButton
       />,
     );

--- a/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
+++ b/src/Components/ResultsCondensedCardTop/ResultsCondensedCardTop.jsx
@@ -49,7 +49,7 @@ const ResultsCondensedCardTop = ({ position, type, isProjectedVacancy, isRecentl
           }
         >
           {useType && <span><FontAwesome name={icon} /> </span>}
-          <h3>{position.title}</h3> <Link to={`/details/${position.id}`}>View position</Link>
+          <h3>{position.title}</h3> {!isProjectedVacancy && <Link to={`/details/${position.id}`}>View position</Link>}
         </div>
       </div>
       <div className="usa-grid-full post-ribbon-container">

--- a/src/Components/ResultsContainer/ResultsContainer.jsx
+++ b/src/Components/ResultsContainer/ResultsContainer.jsx
@@ -4,15 +4,13 @@ import ScrollUpButton from '../ScrollUpButton';
 import PaginationWrapper from '../PaginationWrapper/PaginationWrapper';
 import ResultsList from '../ResultsList/ResultsList';
 import { POSITION_SEARCH_RESULTS, EMPTY_FUNCTION, SAVED_SEARCH_MESSAGE, SAVED_SEARCH_OBJECT,
-         SORT_BY_PARENT_OBJECT, PILL_ITEM_ARRAY, USER_PROFILE, NEW_SAVED_SEARCH_SUCCESS_OBJECT,
+         SORT_BY_PARENT_OBJECT, PILL_ITEM_ARRAY, USER_PROFILE,
          BID_RESULTS } from '../../Constants/PropTypes';
 import Spinner from '../Spinner';
 import Alert from '../Alert/Alert';
 import ResultsControls from '../ResultsControls/ResultsControls';
 import ResultsPillContainer from '../ResultsPillContainer/ResultsPillContainer';
 import SaveNewSearchContainer from '../SaveNewSearchContainer';
-import SaveNewSearchAlert from '../SaveNewSearchAlert';
-import Dismiss from '../Dismiss';
 
 class ResultsContainer extends Component {
   constructor(props) {
@@ -29,18 +27,12 @@ class ResultsContainer extends Component {
     const { results, isLoading, hasErrored, sortBy, pageSize, hasLoaded, totalResults,
             defaultSort, pageSizes, defaultPageSize, refreshKey, pillFilters, userProfile,
             defaultPageNumber, queryParamUpdate, onQueryParamToggle,
-            newSavedSearchHasErrored, saveSearch, newSavedSearchSuccess,
-            currentSavedSearch, newSavedSearchIsSaving, resetSavedSearchAlerts, bidList,
+            newSavedSearchHasErrored, saveSearch,
+            currentSavedSearch, newSavedSearchIsSaving, bidList,
       } = this.props;
     const { isProjectedVacancy } = this.context;
     return (
       <div className="results-container">
-        {
-          newSavedSearchSuccess.title &&
-          <Dismiss onDismiss={resetSavedSearchAlerts}>
-            <SaveNewSearchAlert newSavedSearchSuccess={newSavedSearchSuccess} />
-          </Dismiss>
-        }
         <ResultsPillContainer
           items={pillFilters}
           onPillClick={onQueryParamToggle}
@@ -59,7 +51,6 @@ class ResultsContainer extends Component {
           !isProjectedVacancy ?
             <SaveNewSearchContainer
               saveSearch={saveSearch}
-              newSavedSearchSuccess={newSavedSearchSuccess}
               newSavedSearchHasErrored={newSavedSearchHasErrored}
               currentSavedSearch={currentSavedSearch}
               newSavedSearchIsSaving={newSavedSearchIsSaving}
@@ -85,6 +76,7 @@ class ResultsContainer extends Component {
               results={results}
               isLoading={!hasLoaded}
               favorites={userProfile.favorite_positions}
+              favoritesPV={userProfile.favorite_positions_pv}
               bidList={bidList}
             />
           </div>
@@ -130,11 +122,9 @@ ResultsContainer.propTypes = {
   scrollToTop: PropTypes.func,
   userProfile: USER_PROFILE,
   saveSearch: PropTypes.func.isRequired,
-  newSavedSearchSuccess: NEW_SAVED_SEARCH_SUCCESS_OBJECT.isRequired,
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
   newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
-  resetSavedSearchAlerts: PropTypes.func.isRequired,
   totalResults: PropTypes.number,
   bidList: BID_RESULTS.isRequired,
 };

--- a/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
+++ b/src/Components/ResultsContainer/__snapshots__/ResultsContainer.test.jsx.snap
@@ -215,7 +215,6 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
     currentSavedSearch={Object {}}
     newSavedSearchHasErrored={false}
     newSavedSearchIsSaving={false}
-    newSavedSearchSuccess={Object {}}
     saveSearch={[Function]}
   />
   <div
@@ -228,6 +227,7 @@ exports[`ResultsContainerComponent matches snapshot 1`] = `
     <ResultsList
       bidList={Array []}
       favorites={Array []}
+      favoritesPV={Array []}
       isLoading={false}
       results={
         Object {

--- a/src/Components/ResultsList/ResultsList.jsx
+++ b/src/Components/ResultsList/ResultsList.jsx
@@ -4,7 +4,7 @@ import shortid from 'shortid';
 import ResultsCard from '../../Components/ResultsCard/ResultsCard';
 import { POSITION_SEARCH_RESULTS, FAVORITE_POSITIONS_ARRAY, BID_RESULTS } from '../../Constants/PropTypes';
 
-const ResultsList = ({ results, isLoading, favorites, bidList }) => {
+const ResultsList = ({ results, isLoading, favorites, favoritesPV, bidList }) => {
   const mapResults = results.results || [];
   return (
     <div className={isLoading ? 'results-loading' : null}>
@@ -14,6 +14,7 @@ const ResultsList = ({ results, isLoading, favorites, bidList }) => {
           <ResultsCard
             id={key}
             favorites={favorites}
+            favoritesPV={favoritesPV}
             key={key}
             result={result}
             bidList={bidList}
@@ -28,6 +29,7 @@ ResultsList.propTypes = {
   results: POSITION_SEARCH_RESULTS,
   isLoading: PropTypes.bool,
   favorites: FAVORITE_POSITIONS_ARRAY,
+  favoritesPV: FAVORITE_POSITIONS_ARRAY,
   bidList: BID_RESULTS.isRequired,
 };
 
@@ -35,6 +37,7 @@ ResultsList.defaultProps = {
   results: { results: [] },
   isLoading: false,
   favorites: [],
+  favoritesPV: [],
 };
 
 export default ResultsList;

--- a/src/Components/ResultsPage/ResultsPage.jsx
+++ b/src/Components/ResultsPage/ResultsPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { POSITION_SEARCH_RESULTS, SORT_BY_PARENT_OBJECT, PILL_ITEM_ARRAY,
 ACCORDION_SELECTION_OBJECT, FILTER_ITEMS_ARRAY, USER_PROFILE, BID_RESULTS,
 SAVED_SEARCH_MESSAGE, SAVED_SEARCH_OBJECT, MISSION_DETAILS_ARRAY,
-POST_DETAILS_ARRAY, EMPTY_FUNCTION, NEW_SAVED_SEARCH_SUCCESS_OBJECT } from '../../Constants/PropTypes';
+POST_DETAILS_ARRAY, EMPTY_FUNCTION } from '../../Constants/PropTypes';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
 import ResultsContainer from '../ResultsContainer/ResultsContainer';
 import ResultsSearchHeader from '../ResultsSearchHeader/ResultsSearchHeader';
@@ -25,10 +25,10 @@ class Results extends Component {
     const { results, isLoading, hasErrored, sortBy, defaultKeyword, defaultLocation, resetFilters,
             pillFilters, defaultSort, pageSizes, defaultPageSize, onQueryParamToggle,
             defaultPageNumber, onQueryParamUpdate, filters, userProfile,
-            selectedAccordion, setAccordion, scrollToTop, saveSearch, newSavedSearchSuccess,
+            selectedAccordion, setAccordion, scrollToTop, saveSearch,
             newSavedSearchHasErrored, currentSavedSearch, newSavedSearchIsSaving,
             fetchMissionAutocomplete, missionSearchResults, missionSearchIsLoading,
-            missionSearchHasErrored, resetSavedSearchAlerts, fetchPostAutocomplete,
+            missionSearchHasErrored, fetchPostAutocomplete,
             postSearchResults, postSearchIsLoading, postSearchHasErrored, shouldShowSearchBar,
             bidList, isProjectedVacancy }
       = this.props;
@@ -82,11 +82,9 @@ class Results extends Component {
             scrollToTop={scrollToTop}
             userProfile={userProfile}
             saveSearch={saveSearch}
-            newSavedSearchSuccess={newSavedSearchSuccess}
             newSavedSearchHasErrored={newSavedSearchHasErrored}
             newSavedSearchIsSaving={newSavedSearchIsSaving}
             currentSavedSearch={currentSavedSearch}
-            resetSavedSearchAlerts={resetSavedSearchAlerts}
             bidList={bidList}
           />
         </div>
@@ -116,11 +114,9 @@ Results.propTypes = {
   scrollToTop: PropTypes.func,
   userProfile: USER_PROFILE,
   saveSearch: PropTypes.func.isRequired,
-  newSavedSearchSuccess: NEW_SAVED_SEARCH_SUCCESS_OBJECT.isRequired,
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE.isRequired,
   newSavedSearchIsSaving: PropTypes.bool.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
-  resetSavedSearchAlerts: PropTypes.func.isRequired,
   fetchMissionAutocomplete: PropTypes.func.isRequired,
   missionSearchResults: MISSION_DETAILS_ARRAY.isRequired,
   missionSearchIsLoading: PropTypes.bool.isRequired,

--- a/src/Components/SavedSearchMessages/Success.jsx
+++ b/src/Components/SavedSearchMessages/Success.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+
+const Success = ({ name, isUpdated }) => {
+  let prefix = 'New';
+  let suffix = 'saved';
+  if (isUpdated) {
+    prefix = 'Your saved';
+    suffix = 'updated';
+  }
+  return (
+    <span>{prefix} search with the name {name} has been {suffix}! <Link to="/profile/searches/">Go to Saved Searches</Link>.</span>
+  );
+};
+
+Success.propTypes = {
+  name: PropTypes.string.isRequired,
+  isUpdated: PropTypes.bool,
+};
+
+Success.defaultProps = {
+  isUpdated: false,
+};
+
+export default Success;

--- a/src/Components/SavedSearchMessages/Success.test.jsx
+++ b/src/Components/SavedSearchMessages/Success.test.jsx
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import Success from './Success';
+
+describe('Success', () => {
+  it('is defined', () => {
+    const wrapper = shallow(<Success name="Test Search" />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('is defined when isUpdated is true', () => {
+    const wrapper = shallow(<Success name="Test Search" isUpdated />);
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/Components/SavedSearches/SavedSearches.jsx
+++ b/src/Components/SavedSearches/SavedSearches.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Alert from '../Alert/Alert';
 import ProfileSectionTitle from '../ProfileSectionTitle';
 import SelectForm from '../SelectForm';
 import Spinner from '../Spinner';
 import SavedSearchesList from './SavedSearchesList';
 import {
   SAVED_SEARCH_PARENT_OBJECT,
-  DELETE_SAVED_SEARCH_HAS_ERRORED,
-  DELETE_SAVED_SEARCH_SUCCESS,
-  CLONE_SAVED_SEARCH_HAS_ERRORED,
-  CLONE_SAVED_SEARCH_SUCCESS,
   MAPPED_PARAM_ARRAY,
 } from '../../Constants/PropTypes';
 import { SAVED_SEARCH_SORTS } from '../../Constants/Sort';
@@ -22,21 +17,11 @@ const SavedSearches = (props) => {
     goToSavedSearch,
     deleteSearch,
     onSortChange,
-    deleteSavedSearchIsLoading,
-    deleteSavedSearchHasErrored,
-    deleteSavedSearchSuccess,
-    cloneSavedSearch,
-    cloneSavedSearchIsLoading,
-    cloneSavedSearchHasErrored,
-    cloneSavedSearchSuccess,
     mappedParams,
     filtersIsLoading,
   } = props;
 
-  const isLoading = (
-    filtersIsLoading || savedSearchesIsLoading ||
-    cloneSavedSearchIsLoading || deleteSavedSearchIsLoading
-  );
+  const isLoading = (filtersIsLoading || savedSearchesIsLoading);
 
   return (
     <div
@@ -58,46 +43,6 @@ const SavedSearches = (props) => {
         </div>
       </div>
       {
-        // Deleting a saved search has errored
-        !deleteSavedSearchIsLoading && !deleteSavedSearchSuccess && deleteSavedSearchHasErrored &&
-          <Alert
-            type="error"
-            title="Error"
-            messages={[{ body: deleteSavedSearchHasErrored }]}
-            isAriaLive
-          />
-      }
-      {
-        // Deleting a saved search was successful
-        !deleteSavedSearchIsLoading && deleteSavedSearchSuccess && !deleteSavedSearchHasErrored &&
-          <Alert
-            type="success"
-            title="Success"
-            messages={[{ body: deleteSavedSearchSuccess }]}
-            isAriaLive
-          />
-      }
-      {
-        // Cloning a saved search has errored
-        !cloneSavedSearchIsLoading && !cloneSavedSearchSuccess && cloneSavedSearchHasErrored &&
-          <Alert
-            type="error"
-            title="Error"
-            messages={[{ body: cloneSavedSearchHasErrored }]}
-            isAriaLive
-          />
-      }
-      {
-        // Cloning a saved search was successful
-        !cloneSavedSearchIsLoading && cloneSavedSearchSuccess && !cloneSavedSearchHasErrored &&
-          <Alert
-            type="success"
-            title="Success"
-            messages={[{ body: cloneSavedSearchSuccess }]}
-            isAriaLive
-          />
-      }
-      {
         isLoading &&
           <Spinner type="homepage-position-results" size="big" />
       }
@@ -107,7 +52,6 @@ const SavedSearches = (props) => {
           savedSearches={savedSearches}
           goToSavedSearch={goToSavedSearch}
           deleteSearch={deleteSearch}
-          cloneSavedSearch={cloneSavedSearch}
           mappedParams={mappedParams}
         />
       }
@@ -120,13 +64,6 @@ SavedSearches.propTypes = {
   savedSearchesIsLoading: PropTypes.bool.isRequired,
   goToSavedSearch: PropTypes.func.isRequired,
   deleteSearch: PropTypes.func.isRequired,
-  deleteSavedSearchIsLoading: PropTypes.bool.isRequired,
-  deleteSavedSearchHasErrored: DELETE_SAVED_SEARCH_HAS_ERRORED.isRequired,
-  deleteSavedSearchSuccess: DELETE_SAVED_SEARCH_SUCCESS.isRequired,
-  cloneSavedSearch: PropTypes.func.isRequired,
-  cloneSavedSearchIsLoading: PropTypes.bool.isRequired,
-  cloneSavedSearchHasErrored: CLONE_SAVED_SEARCH_HAS_ERRORED.isRequired,
-  cloneSavedSearchSuccess: CLONE_SAVED_SEARCH_SUCCESS.isRequired,
   mappedParams: MAPPED_PARAM_ARRAY,
   filtersIsLoading: PropTypes.bool.isRequired,
   onSortChange: PropTypes.func.isRequired,

--- a/src/Components/SavedSearches/SavedSearches.test.jsx
+++ b/src/Components/SavedSearches/SavedSearches.test.jsx
@@ -11,13 +11,6 @@ describe('SavedSearchesComponent', () => {
     savedSearchesHasErrored: false,
     goToSavedSearch: () => {},
     deleteSearch: () => {},
-    deleteSavedSearchIsLoading: false,
-    deleteSavedSearchHasErrored: false,
-    deleteSavedSearchSuccess: false,
-    cloneSavedSearchIsLoading: false,
-    cloneSavedSearchHasErrored: false,
-    cloneSavedSearchSuccess: false,
-    cloneSavedSearch: () => {},
     filtersIsLoading: false,
     onSortChange: () => {},
     defaultSort: '',
@@ -30,31 +23,6 @@ describe('SavedSearchesComponent', () => {
       />,
     );
     expect(wrapper).toBeDefined();
-  });
-
-  [
-    { deleteSavedSearchIsLoading: false,
-      deleteSavedSearchSuccess: false,
-      deleteSavedSearchHasErrored: 'message' },
-    { deleteSavedSearchIsLoading: false,
-      deleteSavedSearchSuccess: 'message',
-      deleteSavedSearchHasErrored: false },
-    { cloneSavedSearchIsLoading: false,
-      cloneSavedSearchSuccess: false,
-      cloneSavedSearchHasErrored: 'message' },
-    { cloneSavedSearchIsLoading: false,
-      cloneSavedSearchSuccess: 'message',
-      cloneSavedSearchHasErrored: false },
-  ].forEach((group, i) => {
-    it(`is defined for each alert group - at iterator ${i}`, () => {
-      const wrapper = shallow(
-        <SavedSearches
-          {...props}
-          {...group}
-        />,
-      );
-      expect(wrapper).toBeDefined();
-    });
   });
 
   it('can receive props', () => {

--- a/src/Components/SavedSearches/SavedSearchesList/SavedSearchesList.jsx
+++ b/src/Components/SavedSearches/SavedSearchesList/SavedSearchesList.jsx
@@ -69,7 +69,6 @@ class SavedSearchesList extends Component {
       savedSearches,
       goToSavedSearch,
       deleteSearch,
-      cloneSavedSearch,
       mappedParams,
     } = this.props;
 
@@ -80,7 +79,6 @@ class SavedSearchesList extends Component {
           goToSavedSearch={goToSavedSearch}
           deleteSearch={deleteSearch}
           key={savedSearch.id}
-          cloneSavedSearch={cloneSavedSearch}
           mappedParams={mappedParams}
           /* pass a parentClassName that we can use from the BorderedList component */
           parentClassName="parent-list-container list-transparent"
@@ -111,7 +109,6 @@ SavedSearchesList.propTypes = {
   savedSearches: SAVED_SEARCH_PARENT_OBJECT.isRequired,
   goToSavedSearch: PropTypes.func.isRequired,
   deleteSearch: PropTypes.func.isRequired,
-  cloneSavedSearch: PropTypes.func.isRequired,
   mappedParams: MAPPED_PARAM_ARRAY.isRequired,
 };
 

--- a/src/Components/SavedSearches/SavedSearchesList/SavedSearchesList.test.jsx
+++ b/src/Components/SavedSearches/SavedSearchesList/SavedSearchesList.test.jsx
@@ -10,7 +10,6 @@ describe('SavedSearchesListComponent', () => {
     goToSavedSearch: () => {},
     deleteSavedSearch: () => {},
     deleteSearch: () => {},
-    cloneSavedSearch: () => {},
     mappedParams: [],
   };
 

--- a/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
+++ b/src/Components/SavedSearches/__snapshots__/SavedSearches.test.jsx.snap
@@ -51,7 +51,6 @@ exports[`SavedSearchesComponent matches snapshot 1`] = `
     </div>
   </div>
   <SavedSearchesList
-    cloneSavedSearch={[Function]}
     deleteSearch={[Function]}
     goToSavedSearch={[Function]}
     mappedParams={Array []}

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.jsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
-import { CSVLink } from 'react-csv';
+import { get, mapValues } from 'lodash';
 import queryString from 'query-string';
+import { CSVLink } from '../CSV';
 import { POSITION_SEARCH_SORTS } from '../../Constants/Sort';
 import { fetchResultData } from '../../actions/results';
-import { formatDate } from '../../utilities';
+import { formatDate, getFormattedNumCSV, spliceStringForCSV } from '../../utilities';
 import ExportButton from '../ExportButton';
 
 // Mapping columns to data fields
@@ -31,7 +31,9 @@ export const processData = data => (
     const endDate = get(entry, 'current_assignment.estimated_end_date');
     const formattedEndDate = endDate ? formatDate(endDate) : null;
     return {
-      ...entry,
+      ...mapValues(entry, x => !x ? '' : x), // eslint-disable-line no-confusing-arrow
+      position_number: getFormattedNumCSV(entry.position_number),
+      grade: getFormattedNumCSV(entry.grade),
       estimated_end_date: formattedEndDate,
     };
   })
@@ -88,11 +90,13 @@ class SearchResultsExportLink extends Component {
         <ExportButton onClick={this.onClick} isLoading={isLoading} />
         <CSVLink
           tabIndex="-1"
+          transform={spliceStringForCSV}
           ref={(x) => { this.csvLink = x; }}
           target="_blank"
           filename={this.props.filename}
           data={data}
           headers={HEADERS}
+          uFEFF={false}
         />
       </div>
     );

--- a/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
+++ b/src/Components/SearchResultsExportLink/SearchResultsExportLink.test.jsx
@@ -45,12 +45,12 @@ describe('SearchResultsExportLink', () => {
   it('processes data correctly', () => {
     const data = [{ a: 1, b: 2, current_assignment: { estimated_end_date: '2019-01-08T00:00:00Z' } }];
     const output = processData(data);
-    expect(output).toEqual([
+    expect(output[0]).toMatchObject(
       { a: 1,
         b: 2,
         current_assignment: { estimated_end_date: '2019-01-08T00:00:00Z' },
         estimated_end_date: '01/07/2019' },
-    ]);
+    );
   });
 
   it('matches snapshot', () => {

--- a/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
+++ b/src/Components/SearchResultsExportLink/__snapshots__/SearchResultsExportLink.test.jsx.snap
@@ -73,7 +73,8 @@ exports[`SearchResultsExportLink matches snapshot 1`] = `
     separator=","
     tabIndex="-1"
     target="_blank"
-    uFEFF={true}
+    transform={[Function]}
+    uFEFF={false}
   />
 </div>
 `;

--- a/src/Constants/SystemMessages.js
+++ b/src/Constants/SystemMessages.js
@@ -1,5 +1,6 @@
 import FavoriteSuccess from '../Components/FavoriteMessages/Success';
 import BidAddSuccess from '../Components/BidListMessages/Success';
+import SavedSearchSuccess from '../Components/SavedSearchMessages/Success';
 
 export const DEFAULT_TEXT = 'None listed';
 
@@ -57,11 +58,14 @@ export const SUBMIT_BID_ERROR = 'Error trying to submit this bid.';
 
 export const NEW_SAVED_SEARCH_SUCCESS_TITLE = 'Success';
 export const UPDATED_SAVED_SEARCH_SUCCESS_TITLE = 'Saved search updated';
+export const DELETE_SAVED_SEARCH_SUCCESS_TITLE = 'Success';
+export const DELETE_SAVED_SEARCH_ERROR_TITLE = 'Saved search error';
 
-export const NEW_SAVED_SEARCH_SUCCESS = name =>
-  `New search with the name "${name}" has been saved! You can go to your profile to view all of your saved searches.`;
-export const UPDATED_SAVED_SEARCH_SUCCESS = name =>
-  `Your saved search with the name "${name}" has been updated! You can go to your profile to view all of your saved searches.`;
+
+export const NEW_SAVED_SEARCH_SUCCESS = name => SavedSearchSuccess({ name });
+export const UPDATED_SAVED_SEARCH_SUCCESS = name => SavedSearchSuccess({ name, isUpdated: true });
+export const DELETE_SAVED_SEARCH_SUCCESS = 'Successfully deleted the selected search';
+export const DELETE_SAVED_SEARCH_ERROR = 'An error occurred trying to delete this search.';
 
 export const CANNOT_BID_SUFFIX = ', but can be favorited for the future.';
 export const CANNOT_BID_DEFAULT = `This position is not available to bid on${CANNOT_BID_SUFFIX}`;

--- a/src/Constants/SystemMessages.test.js
+++ b/src/Constants/SystemMessages.test.js
@@ -53,14 +53,13 @@ describe('SystemMessages', () => {
   });
 
   it('should have all expected messages that accept parameters defined', () => {
-    const textToCheck = 'test_word';
     const messages = [
       'UPDATED_SAVED_SEARCH_SUCCESS',
       'NEW_SAVED_SEARCH_SUCCESS',
     ];
 
     messages.forEach((message) => {
-      expect(SystemMessages[message](textToCheck).indexOf(textToCheck)).toBeDefined();
+      expect(SystemMessages[message]('name')).toBeDefined();
     });
   });
 

--- a/src/Containers/BidTracker/BidTracker.test.jsx
+++ b/src/Containers/BidTracker/BidTracker.test.jsx
@@ -41,7 +41,8 @@ describe('BidTracker', () => {
     />);
     const spy = sinon.spy(wrapper.instance(), 'scrollToId');
     wrapper.instance().componentDidUpdate();
-    sinon.assert.calledOnce(spy);
+    // called once on mount, once after didUpdate()
+    sinon.assert.calledTwice(spy);
   });
 
   it('calls scrollIntoView when scrollToId is called', () => {

--- a/src/Containers/BidderPortfolio/BidderPortfolio.jsx
+++ b/src/Containers/BidderPortfolio/BidderPortfolio.jsx
@@ -16,7 +16,7 @@ class BidderPortfolio extends Component {
     this.state = {
       key: 0,
       query: { value: window.location.search.replace('?', '') || '' },
-      defaultPageSize: { value: 8 },
+      defaultPageSize: { value: 24 },
       defaultPageNumber: { value: 1 },
       defaultKeyword: { value: '' },
     };

--- a/src/Containers/Compare/Compare.jsx
+++ b/src/Containers/Compare/Compare.jsx
@@ -50,7 +50,7 @@ export class Compare extends Component {
     return (
       <CompareList
         compare={comparisons}
-        favorites={favoritePositions}
+        favorites={favoritePositions.favorites}
         hasErrored={hasErrored}
         isLoading={isLoading}
         onToggle={this.onToggle}

--- a/src/Containers/Dashboard/Dashboard.jsx
+++ b/src/Containers/Dashboard/Dashboard.jsx
@@ -33,7 +33,7 @@ class DashboardContainer extends Component {
         notificationsIsLoading={notificationsIsLoading}
         bidList={bidList.results}
         bidListIsLoading={bidListIsLoading}
-        favoritePositions={favoritePositions.results}
+        favoritePositions={favoritePositions.favorites}
         favoritePositionsIsLoading={favoritePositionsIsLoading}
         favoritePositionsHasErrored={favoritePositionsHasErrored}
         submitBidPosition={submitBidPosition}

--- a/src/Containers/Favorite/Favorite.jsx
+++ b/src/Containers/Favorite/Favorite.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { userProfileToggleFavoritePosition } from '../../actions/userProfile';
 import Favorite from '../../Components/Favorite';
 import { SetType } from '../../Constants/PropTypes';
@@ -25,10 +26,12 @@ FavoriteContainer.propTypes = {
   isLoading: SetType,
   hasErrored: PropTypes.bool.isRequired,
   refKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string.isRequired]).isRequired,
+  isPV: PropTypes.bool,
 };
 
 FavoriteContainer.defaultProps = {
   isLoading: new Set(),
+  isPV: false,
 };
 
 export const mapStateToProps = state => ({
@@ -36,9 +39,10 @@ export const mapStateToProps = state => ({
   hasErrored: state.userProfileFavoritePositionHasErrored || false,
 });
 
-export const mapDispatchToProps = dispatch => ({
-  onToggle: (id, remove, refresh = false) =>
-    dispatch(userProfileToggleFavoritePosition(id, remove, refresh)),
+export const mapDispatchToProps = (dispatch, ownProps) => ({
+  onToggle: (id, remove, refresh = false) => {
+    dispatch(userProfileToggleFavoritePosition(id, remove, refresh, get(ownProps, 'isPV')));
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FavoriteContainer);

--- a/src/Containers/Favorites/Favorites.jsx
+++ b/src/Containers/Favorites/Favorites.jsx
@@ -42,7 +42,8 @@ class FavoritePositionsContainer extends Component {
     return (
       <div>
         <FavoritePositions
-          favorites={favoritePositions}
+          favorites={favoritePositions.favorites}
+          favoritesPV={favoritePositions.favoritesPV}
           favoritePositionsIsLoading={favoritePositionsIsLoading}
           favoritePositionsHasErrored={favoritePositionsHasErrored}
           toggleFavorite={this.onToggleFavorite}

--- a/src/Containers/Results/Results.jsx
+++ b/src/Containers/Results/Results.jsx
@@ -10,7 +10,7 @@ import { scrollToTop, cleanQueryParams, getAssetPath } from '../../utilities';
 import { resultsFetchData } from '../../actions/results';
 import { filtersFetchData } from '../../actions/filters/filters';
 import { bidListFetchData } from '../../actions/bidList';
-import { saveSearch, routeChangeResetState } from '../../actions/savedSearch';
+import { saveSearch } from '../../actions/savedSearch';
 import { missionSearchFetchData } from '../../actions/autocomplete/missionAutocomplete';
 import { postSearchFetchData } from '../../actions/autocomplete/postAutocomplete';
 import { setSelectedAccordion } from '../../actions/selectedAccordion';
@@ -18,8 +18,7 @@ import { toggleSearchBar } from '../../actions/showSearchBar';
 import ResultsPage from '../../Components/ResultsPage/ResultsPage';
 import CompareDrawer from '../../Components/CompareDrawer';
 import { POSITION_SEARCH_RESULTS, FILTERS_PARENT, ACCORDION_SELECTION_OBJECT,
-USER_PROFILE, SAVED_SEARCH_MESSAGE, NEW_SAVED_SEARCH_SUCCESS_OBJECT,
-SAVED_SEARCH_OBJECT, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY,
+USER_PROFILE, SAVED_SEARCH_MESSAGE, SAVED_SEARCH_OBJECT, MISSION_DETAILS_ARRAY, POST_DETAILS_ARRAY,
 EMPTY_FUNCTION, BID_LIST } from '../../Constants/PropTypes';
 import { ACCORDION_SELECTION } from '../../Constants/DefaultProps';
 import { LOGIN_REDIRECT } from '../../login/routes';
@@ -48,9 +47,7 @@ class Results extends Component {
   }
 
   componentWillMount() {
-    const { resetSavedSearchAlerts, isAuthorized, onNavigateTo } = this.props;
-    // clear out old alert messages
-    resetSavedSearchAlerts();
+    const { isAuthorized, onNavigateTo } = this.props;
     // check auth
     if (!isAuthorized()) {
       onNavigateTo(LOGIN_REDIRECT);
@@ -206,9 +203,8 @@ class Results extends Component {
     const { results, hasErrored, isLoading, filters,
             selectedAccordion, setAccordion, userProfile, fetchMissionAutocomplete,
             missionSearchResults, missionSearchIsLoading, missionSearchHasErrored,
-            resetSavedSearchAlerts, currentSavedSearch,
-            newSavedSearchSuccess, newSavedSearchIsSaving, newSavedSearchHasErrored,
-            fetchPostAutocomplete, postSearchResults, postSearchIsLoading,
+            currentSavedSearch, newSavedSearchIsSaving,
+            newSavedSearchHasErrored, fetchPostAutocomplete, postSearchResults, postSearchIsLoading,
             postSearchHasErrored, shouldShowSearchBar, bidList } = this.props;
     return (
       <div>
@@ -231,12 +227,10 @@ class Results extends Component {
           setAccordion={setAccordion}
           scrollToTop={scrollToTop}
           userProfile={userProfile}
-          newSavedSearchSuccess={newSavedSearchSuccess}
           newSavedSearchIsSaving={newSavedSearchIsSaving}
           newSavedSearchHasErrored={newSavedSearchHasErrored}
           saveSearch={this.saveSearch}
           currentSavedSearch={currentSavedSearch}
-          resetSavedSearchAlerts={resetSavedSearchAlerts}
           fetchMissionAutocomplete={fetchMissionAutocomplete}
           missionSearchResults={missionSearchResults}
           missionSearchIsLoading={missionSearchIsLoading}
@@ -271,12 +265,10 @@ Results.propTypes = {
   selectedAccordion: ACCORDION_SELECTION_OBJECT,
   setAccordion: PropTypes.func.isRequired,
   userProfile: USER_PROFILE,
-  newSavedSearchSuccess: NEW_SAVED_SEARCH_SUCCESS_OBJECT,
   newSavedSearchIsSaving: PropTypes.bool.isRequired,
   newSavedSearchHasErrored: SAVED_SEARCH_MESSAGE,
   saveSearch: PropTypes.func.isRequired,
   currentSavedSearch: SAVED_SEARCH_OBJECT,
-  resetSavedSearchAlerts: PropTypes.func.isRequired,
   fetchMissionAutocomplete: PropTypes.func.isRequired,
   missionSearchResults: MISSION_DETAILS_ARRAY.isRequired,
   missionSearchIsLoading: PropTypes.bool.isRequired,
@@ -301,11 +293,9 @@ Results.defaultProps = {
   filtersIsLoading: true,
   selectedAccordion: ACCORDION_SELECTION,
   userProfile: {},
-  newSavedSearchSuccess: {},
   newSavedSearchHasErrored: false,
   newSavedSearchIsSaving: false,
   currentSavedSearch: {},
-  resetSavedSearchAlerts: EMPTY_FUNCTION,
   fetchMissionAutocomplete: EMPTY_FUNCTION,
   missionSearchResults: [],
   missionSearchIsLoading: false,
@@ -333,7 +323,6 @@ const mapStateToProps = state => ({
   selectedAccordion: state.selectedAccordion,
   routerLocations: state.routerLocations,
   userProfile: state.userProfile,
-  newSavedSearchSuccess: state.newSavedSearchSuccess,
   newSavedSearchIsSaving: state.newSavedSearchIsSaving,
   newSavedSearchHasErrored: state.newSavedSearchHasErrored,
   currentSavedSearch: state.currentSavedSearch,
@@ -355,7 +344,6 @@ export const mapDispatchToProps = dispatch => ({
   setAccordion: accordion => dispatch(setSelectedAccordion(accordion)),
   onNavigateTo: dest => dispatch(push(dest)),
   saveSearch: (object, id) => dispatch(saveSearch(object, id)),
-  resetSavedSearchAlerts: () => dispatch(routeChangeResetState()),
   fetchMissionAutocomplete: query => dispatch(missionSearchFetchData(query)),
   fetchPostAutocomplete: query => dispatch(postSearchFetchData(query)),
   toggleSearchBarVisibility: bool => dispatch(toggleSearchBar(bool)),

--- a/src/Containers/SavedSearches/SavedSearches.jsx
+++ b/src/Containers/SavedSearches/SavedSearches.jsx
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { push } from 'react-router-redux';
-import { savedSearchesFetchData, setCurrentSavedSearch, deleteSavedSearch, routeChangeResetState,
-cloneSavedSearch } from '../../actions/savedSearch';
-import { SAVED_SEARCH_PARENT_OBJECT, DELETE_SAVED_SEARCH_HAS_ERRORED, DELETE_SAVED_SEARCH_SUCCESS,
-CLONE_SAVED_SEARCH_HAS_ERRORED, CLONE_SAVED_SEARCH_SUCCESS, EMPTY_FUNCTION } from '../../Constants/PropTypes';
+import { savedSearchesFetchData, setCurrentSavedSearch, deleteSavedSearch } from '../../actions/savedSearch';
+import { SAVED_SEARCH_PARENT_OBJECT } from '../../Constants/PropTypes';
 import { DEFAULT_USER_PROFILE, POSITION_RESULTS_OBJECT } from '../../Constants/DefaultProps';
 import SavedSearchesMap from '../SavedSearchesMap';
 import { formQueryString } from '../../utilities';
@@ -23,8 +21,6 @@ class SavedSearchesContainer extends Component {
 
   componentWillMount() {
     this.getSavedSearches();
-    // reset the alert messages
-    this.props.routeChangeResetState();
   }
 
   getSavedSearches() {
@@ -45,10 +41,7 @@ class SavedSearchesContainer extends Component {
   }
 
   render() {
-    const { savedSearches, deleteSearch, cloneSearch, ChildElement,
-      savedSearchesIsLoading, deleteSavedSearchHasErrored,
-      deleteSavedSearchIsLoading, deleteSavedSearchSuccess, cloneSavedSearchIsLoading,
-      cloneSavedSearchHasErrored, cloneSavedSearchSuccess } = this.props;
+    const { savedSearches, deleteSearch, ChildElement, savedSearchesIsLoading } = this.props;
     return (
       <div className="saved-search-parent-container">
         <SavedSearchesMap
@@ -56,13 +49,6 @@ class SavedSearchesContainer extends Component {
           savedSearchesIsLoading={savedSearchesIsLoading}
           goToSavedSearch={this.goToSavedSearch}
           deleteSearch={deleteSearch}
-          deleteSavedSearchIsLoading={deleteSavedSearchIsLoading}
-          deleteSavedSearchHasErrored={deleteSavedSearchHasErrored}
-          deleteSavedSearchSuccess={deleteSavedSearchSuccess}
-          cloneSavedSearchIsLoading={cloneSavedSearchIsLoading}
-          cloneSavedSearchHasErrored={cloneSavedSearchHasErrored}
-          cloneSavedSearchSuccess={cloneSavedSearchSuccess}
-          cloneSavedSearch={cloneSearch}
           ChildElement={ChildElement}
           onSortChange={this.getSortedSearches}
         />
@@ -78,14 +64,6 @@ SavedSearchesContainer.propTypes = {
   savedSearchesIsLoading: PropTypes.bool.isRequired,
   setCurrentSavedSearch: PropTypes.func.isRequired,
   deleteSearch: PropTypes.func.isRequired,
-  deleteSavedSearchIsLoading: PropTypes.bool.isRequired,
-  deleteSavedSearchHasErrored: DELETE_SAVED_SEARCH_HAS_ERRORED.isRequired,
-  deleteSavedSearchSuccess: DELETE_SAVED_SEARCH_SUCCESS.isRequired,
-  routeChangeResetState: PropTypes.func.isRequired,
-  cloneSearch: PropTypes.func.isRequired,
-  cloneSavedSearchIsLoading: PropTypes.bool.isRequired,
-  cloneSavedSearchHasErrored: CLONE_SAVED_SEARCH_HAS_ERRORED.isRequired,
-  cloneSavedSearchSuccess: CLONE_SAVED_SEARCH_SUCCESS.isRequired,
   ChildElement: PropTypes.func.isRequired,
 };
 
@@ -95,14 +73,6 @@ SavedSearchesContainer.defaultProps = {
   savedSearches: POSITION_RESULTS_OBJECT,
   savedSearchesIsLoading: true,
   savedSearchesHasErrored: false,
-  deleteSavedSearchIsLoading: false,
-  deleteSavedSearchHasErrored: false,
-  deleteSavedSearchSuccess: false,
-  routeChangeResetState: EMPTY_FUNCTION,
-  cloneSearch: EMPTY_FUNCTION,
-  cloneSavedSearchIsLoading: false,
-  cloneSavedSearchHasErrored: false,
-  cloneSavedSearchSuccess: false,
 };
 
 SavedSearchesContainer.contextTypes = {
@@ -115,12 +85,6 @@ const mapStateToProps = (state, ownProps) => ({
   savedSearches: state.savedSearchesSuccess,
   savedSearchesIsLoading: state.savedSearchesIsLoading,
   savedSearchesHasErrored: state.savedSearchesHasErrored,
-  deleteSavedSearchIsLoading: state.deleteSavedSearchIsLoading,
-  deleteSavedSearchHasErrored: state.deleteSavedSearchHasErrored,
-  deleteSavedSearchSuccess: state.deleteSavedSearchSuccess,
-  cloneSavedSearchIsLoading: state.cloneSavedSearchIsLoading,
-  cloneSavedSearchHasErrored: state.cloneSavedSearchHasErrored,
-  cloneSavedSearchSuccess: state.cloneSavedSearchSuccess,
 });
 
 export const mapDispatchToProps = dispatch => ({
@@ -128,8 +92,6 @@ export const mapDispatchToProps = dispatch => ({
   savedSearchesFetchData: sortType => dispatch(savedSearchesFetchData(sortType)),
   setCurrentSavedSearch: e => dispatch(setCurrentSavedSearch(e)),
   deleteSearch: id => dispatch(deleteSavedSearch(id)),
-  routeChangeResetState: () => dispatch(routeChangeResetState()),
-  cloneSearch: id => dispatch(cloneSavedSearch(id)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(SavedSearchesContainer));

--- a/src/Containers/SavedSearchesMap/SavedSearchesMap.jsx
+++ b/src/Containers/SavedSearchesMap/SavedSearchesMap.jsx
@@ -7,10 +7,6 @@ import { mapSavedSearchesToSingleQuery } from '../../utilities';
 import { DEFAULT_USER_PROFILE, POSITION_RESULTS_OBJECT } from '../../Constants/DefaultProps';
 import {
   SAVED_SEARCH_PARENT_OBJECT,
-  DELETE_SAVED_SEARCH_HAS_ERRORED,
-  DELETE_SAVED_SEARCH_SUCCESS,
-  CLONE_SAVED_SEARCH_HAS_ERRORED,
-  CLONE_SAVED_SEARCH_SUCCESS,
   EMPTY_FUNCTION,
   FILTERS_PARENT,
 } from '../../Constants/PropTypes';
@@ -35,7 +31,6 @@ class SavedSearchesMap extends Component {
       fetchFilters,
       savedSearches,
       savedSearchesIsLoading,
-      cloneSavedSearchIsLoading,
       deleteSavedSearchIsLoading,
     } = props;
 
@@ -44,7 +39,6 @@ class SavedSearchesMap extends Component {
     // is anything loading from the parent? if so, don't try to fetch filters
     const isLoading = (
       savedSearchesIsLoading ||
-      cloneSavedSearchIsLoading ||
       deleteSavedSearchIsLoading
     );
 
@@ -68,10 +62,8 @@ class SavedSearchesMap extends Component {
   }
 
   render() {
-    const { savedSearches, deleteSearch, filters, ChildElement, cloneSavedSearch,
-      savedSearchesHasErrored, savedSearchesIsLoading, deleteSavedSearchHasErrored,
-      deleteSavedSearchIsLoading, deleteSavedSearchSuccess, cloneSavedSearchIsLoading,
-      cloneSavedSearchHasErrored, cloneSavedSearchSuccess, goToSavedSearch,
+    const { savedSearches, deleteSearch, filters, ChildElement,
+      savedSearchesHasErrored, savedSearchesIsLoading, goToSavedSearch,
       filtersIsLoading, onSortChange } = this.props;
     const props = {
       savedSearches,
@@ -79,14 +71,7 @@ class SavedSearchesMap extends Component {
       filters,
       savedSearchesHasErrored,
       savedSearchesIsLoading,
-      deleteSavedSearchHasErrored,
-      deleteSavedSearchIsLoading,
-      deleteSavedSearchSuccess,
-      cloneSavedSearchIsLoading,
-      cloneSavedSearchHasErrored,
-      cloneSavedSearchSuccess,
       goToSavedSearch,
-      cloneSavedSearch,
       filtersIsLoading,
       onSortChange,
       mappedParams: filters.mappedParams || [],
@@ -103,13 +88,6 @@ SavedSearchesMap.propTypes = {
   savedSearchesIsLoading: PropTypes.bool.isRequired,
   savedSearchesHasErrored: PropTypes.bool.isRequired,
   deleteSearch: PropTypes.func.isRequired,
-  deleteSavedSearchIsLoading: PropTypes.bool.isRequired,
-  deleteSavedSearchHasErrored: DELETE_SAVED_SEARCH_HAS_ERRORED.isRequired,
-  deleteSavedSearchSuccess: DELETE_SAVED_SEARCH_SUCCESS.isRequired,
-  cloneSavedSearch: PropTypes.func.isRequired,
-  cloneSavedSearchIsLoading: PropTypes.bool.isRequired,
-  cloneSavedSearchHasErrored: CLONE_SAVED_SEARCH_HAS_ERRORED.isRequired,
-  cloneSavedSearchSuccess: CLONE_SAVED_SEARCH_SUCCESS.isRequired,
   filters: FILTERS_PARENT,
   goToSavedSearch: PropTypes.func.isRequired,
   fetchFilters: PropTypes.func.isRequired,
@@ -124,14 +102,7 @@ SavedSearchesMap.defaultProps = {
   savedSearches: POSITION_RESULTS_OBJECT,
   savedSearchesIsLoading: false,
   savedSearchesHasErrored: false,
-  deleteSavedSearchIsLoading: false,
-  deleteSavedSearchHasErrored: false,
-  deleteSavedSearchSuccess: false,
   routeChangeResetState: EMPTY_FUNCTION,
-  cloneSavedSearch: EMPTY_FUNCTION,
-  cloneSavedSearchIsLoading: false,
-  cloneSavedSearchHasErrored: false,
-  cloneSavedSearchSuccess: false,
   filters: { filters: [] },
   goToSavedSearch: EMPTY_FUNCTION,
   fetchFilters: EMPTY_FUNCTION,

--- a/src/Containers/queryParams.js
+++ b/src/Containers/queryParams.js
@@ -1,5 +1,5 @@
 import queryString from 'query-string';
-import { toString } from 'lodash';
+import { get } from 'lodash';
 
 // when we need to update an existing query string with properties from an object
 function queryParamUpdate(newQueryObject, oldQueryString, returnAsObject = false) {
@@ -16,7 +16,8 @@ function queryParamUpdate(newQueryObject, oldQueryString, returnAsObject = false
   const newQuery = Object.assign({}, parsedQuery, newQueryObject);
   // remove any params with no value
   Object.keys(newQuery).forEach((key) => {
-    if (!(toString(newQuery[key]) && toString(newQuery[key]).length)) {
+    const newQuery$ = get(newQuery, key) || '';
+    if (!(newQuery$.toString().length)) {
       delete newQuery[key];
     }
   });

--- a/src/__mocks__/userObject.js
+++ b/src/__mocks__/userObject.js
@@ -48,6 +48,14 @@ export const bidderUserObject = {
       representation: '[00180000] OMS (DCM) (Addis Ababa, Ethiopia)',
     },
   ],
+  favorite_positions_pv: [
+    {
+      id: 10,
+    },
+    {
+      id: 20,
+    },
+  ],
 };
 
 export const cdoUserObject = Object.assign({}, bidderUserObject, { cdo: null, is_cdo: true });

--- a/src/actions/favoritePositions.js
+++ b/src/actions/favoritePositions.js
@@ -1,3 +1,4 @@
+import { get } from 'lodash';
 import api from '../api';
 
 export function favoritePositionsHasErrored(bool) {
@@ -25,19 +26,54 @@ export function favoritePositionsFetchData(sortType) {
   return (dispatch) => {
     dispatch(favoritePositionsIsLoading(true));
     dispatch(favoritePositionsHasErrored(false));
+    const data$ = { favorites: [], favoritesPV: [] };
     let url = '/position/favorites/';
-    if (sortType) { url += `?ordering=${sortType}`; }
+    let urlPV = '/projected_vacancy/favorites/';
+    if (sortType) {
+      const append = `?ordering=${sortType}`;
+      url += append;
+      urlPV += append;
+    }
 
-    api().get(url)
-      .then(response => response.data)
-      .then((results) => {
-        dispatch(favoritePositionsFetchDataSuccess(results));
-        dispatch(favoritePositionsHasErrored(false));
-        dispatch(favoritePositionsIsLoading(false));
-      })
-      .catch(() => {
+    const fetchFavorites = () =>
+      api().get(url)
+        .then(({ data }) => data)
+        .catch(error => error);
+
+    const fetchPVFavorites = () =>
+      api().get(urlPV)
+        .then(({ data }) => data)
+        .catch(error => error);
+
+    const queryProms = [fetchFavorites(), fetchPVFavorites()];
+
+    Promise.all(queryProms)
+    .then((results) => {
+      // if any promise returned with errors, return the error
+      let err;
+      results.forEach((result) => {
+        if (result instanceof Error) {
+          err = result;
+        }
+      });
+      if (err) {
         dispatch(favoritePositionsHasErrored(true));
         dispatch(favoritePositionsIsLoading(false));
-      });
+      } else {
+        // object 0 is favorites
+        data$.favorites = get(results, '[0].results', []);
+        data$.results = get(results, '[0].results', []);
+        // object 1 is PV favorites
+        // add PV property
+        data$.favoritesPV = get(results, '[1].results', []).map(m => ({ ...m, isPV: true }));
+        dispatch(favoritePositionsFetchDataSuccess(data$));
+        dispatch(favoritePositionsHasErrored(false));
+        dispatch(favoritePositionsIsLoading(false));
+      }
+    })
+    .catch(() => {
+      dispatch(favoritePositionsHasErrored(true));
+      dispatch(favoritePositionsIsLoading(false));
+    });
   };
 }

--- a/src/actions/glossary.js
+++ b/src/actions/glossary.js
@@ -87,7 +87,7 @@ export function glossaryFetchData(bypassLoading = false) {
     }
 
     api()
-      .get('/glossary/?is_archived=false')
+      .get('/glossary/?is_archived=false&limit=500')
       .then(({ data }) => {
         dispatch(glossaryFetchDataSuccess(data));
         dispatch(glossaryIsLoading(false));
@@ -109,7 +109,7 @@ export function glossaryEditorFetchData(bypassLoading = false) {
     }
 
     api()
-      .get('/glossary/')
+      .get('/glossary/?limit=500')
       .then(({ data }) => {
         dispatch(glossaryEditorFetchDataSuccess(data));
         dispatch(glossaryEditorIsLoading(false));

--- a/src/actions/glossary.test.js
+++ b/src/actions/glossary.test.js
@@ -6,11 +6,11 @@ const { mockStore, mockAdapter } = setupAsyncMocks();
 
 describe('async actions', () => {
   beforeEach(() => {
-    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/?limit=500').reply(200,
       { results: glossaryItems },
     );
 
-    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/?is_archived=false').reply(200,
+    mockAdapter.onGet('http://localhost:8000/api/v1/glossary/?is_archived=false&limit=500').reply(200,
       { results: glossaryItems },
     );
 

--- a/src/actions/savedSearch.js
+++ b/src/actions/savedSearch.js
@@ -1,6 +1,7 @@
 import api from '../api';
 import * as SystemMessages from '../Constants/SystemMessages';
 import { propOrDefault } from '../utilities';
+import { toastSuccess, toastError } from './toast';
 
 export function newSavedSearchHasErrored(bool) {
   return {
@@ -141,11 +142,19 @@ export function deleteSavedSearch(id) {
         dispatch(deleteSavedSearchIsLoading(false));
         dispatch(deleteSavedSearchHasErrored(false));
         dispatch(deleteSavedSearchSuccess('Successfully deleted the selected search.'));
+        dispatch(toastSuccess(
+          SystemMessages.DELETE_SAVED_SEARCH_SUCCESS,
+          SystemMessages.DELETE_SAVED_SEARCH_SUCCESS_TITLE,
+        ));
         dispatch(currentSavedSearch(false));
         dispatch(savedSearchesFetchData());
       })
       .catch((err) => {
-        dispatch(deleteSavedSearchHasErrored(JSON.stringify(err.response.data) || 'An error occurred trying to delete this search.'));
+        dispatch(deleteSavedSearchHasErrored(JSON.stringify(propOrDefault(err, 'response.data', 'An error occurred trying to delete this search.'))));
+        dispatch(toastError(
+          SystemMessages.DELETE_SAVED_SEARCH_ERROR,
+          SystemMessages.DELETE_SAVED_SEARCH_ERROR_TITLE,
+        ));
         dispatch(deleteSavedSearchIsLoading(false));
         dispatch(deleteSavedSearchSuccess(false));
       });
@@ -219,11 +228,26 @@ export function saveSearch(data, id) {
           { title: SystemMessages.NEW_SAVED_SEARCH_SUCCESS_TITLE,
             message: SystemMessages.NEW_SAVED_SEARCH_SUCCESS(response.data.name) },
         ));
+        // eslint-disable-next-line
+        const success = id => id ?
+          dispatch(toastSuccess(
+            SystemMessages.UPDATED_SAVED_SEARCH_SUCCESS(response.data.name),
+            SystemMessages.UPDATED_SAVED_SEARCH_SUCCESS_TITLE,
+          )) :
+          dispatch(toastSuccess(
+            SystemMessages.NEW_SAVED_SEARCH_SUCCESS(response.data.name),
+            SystemMessages.NEW_SAVED_SEARCH_SUCCESS_TITLE,
+          ));
+        success(id);
         dispatch(setCurrentSavedSearch(response.data));
       })
       .catch((err) => {
         dispatch(newSavedSearchHasErrored(
           { title: 'Error', message: propOrDefault(err, 'response.data', 'An error occurred trying to save this search.') },
+        ));
+        dispatch(toastError(
+          'An error occurred trying to save this search.',
+          'Error',
         ));
         dispatch(newSavedSearchIsSaving(false));
         dispatch(newSavedSearchSuccess(false));

--- a/src/actions/userProfile.js
+++ b/src/actions/userProfile.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { indexOf } from 'lodash';
+import { get, indexOf } from 'lodash';
 
 import api from '../api';
 import { favoritePositionsFetchData } from './favoritePositions';
@@ -63,18 +63,22 @@ export function userProfileFetchData(bypass, cb) {
     const getUserAccount = () => api().get('/profile/');
     // permissions
     const getUserPermissions = () => api().get('/permission/user/');
+    // PV favorites
+    const getPVFavorites = () => api().get('/projected_vacancy/favorites/');
 
     // use api' Promise.all to fetch the profile and permissions, and then combine them
     // into one object
-    axios.all([getUserAccount(), getUserPermissions()])
-      .then(axios.spread((acct, perms) => {
+    axios.all([getUserAccount(), getUserPermissions(), getPVFavorites()])
+      .then(axios.spread((acct, perms, pvFavs) => {
         // form the userProfile object
         const account = acct.data;
         const permissions = perms.data;
+        const pvFavorites = get(pvFavs, 'data.results', []).map(m => ({ id: m.id }));
         const newProfileObject = {
           ...account,
           is_superuser: indexOf(permissions.groups, 'superuser') > -1,
           permission_groups: permissions.groups,
+          favorite_positions_pv: pvFavorites,
         };
 
         // then perform dispatches
@@ -104,12 +108,13 @@ export function userProfileFetchData(bypass, cb) {
 // Since we have to pass the entire array to the API, we want to make sure it's accurate.
 // If we need a full refresh of Favorite Positions, such as for the profile's favorite sub-section,
 // we can pass a third arg, refreshFavorites.
-export function userProfileToggleFavoritePosition(id, remove, refreshFavorites = false) {
+export function userProfileToggleFavoritePosition(id, remove, refreshFavorites = false,
+  isPV = false) {
   const idString = id.toString();
   return (dispatch) => {
     const config = {
       method: remove ? 'delete' : 'put',
-      url: `/position/${idString}/favorite/`,
+      url: isPV ? `/projected_vacancy/${idString}/favorite/` : `/position/${idString}/favorite/`,
     };
 
     /**
@@ -119,14 +124,14 @@ export function userProfileToggleFavoritePosition(id, remove, refreshFavorites =
     const getAction = () => api()(config);
 
     // position
-    const getPosition = () => api().get(`/position/${id}/`);
+    const getPosition = () => api().get(isPV ? `/fsbid/projected_vacancies/position_number__in=${id}/` : `/position/${id}/`);
 
     dispatch(userProfileFavoritePositionIsLoading(true, id));
     dispatch(userProfileFavoritePositionHasErrored(false));
 
     axios.all([getAction(), getPosition()])
       .then(axios.spread((action, position) => {
-        const pos = position.data;
+        const pos = isPV ? get(position, 'data.results[0]', {}) : position.data;
         const message = remove ?
           SystemMessages.DELETE_FAVORITE_SUCCESS(pos) : SystemMessages.ADD_FAVORITE_SUCCESS(pos);
         const title = remove ? SystemMessages.DELETE_FAVORITE_TITLE

--- a/src/reducers/favoritePositions/favoritePositions.js
+++ b/src/reducers/favoritePositions/favoritePositions.js
@@ -14,7 +14,7 @@ export function favoritePositionsIsLoading(state = false, action) {
       return state;
   }
 }
-export function favoritePositions(state = { results: [] }, action) {
+export function favoritePositions(state = { favorites: [], favoritesPV: [] }, action) {
   switch (action.type) {
     case 'FAVORITE_POSITIONS_FETCH_DATA_SUCCESS':
       return action.results;

--- a/src/sass/_glossaryEditor.scss
+++ b/src/sass/_glossaryEditor.scss
@@ -1,4 +1,8 @@
 .glossary-editor-page {
+  h2 {
+    color: initial;
+  }
+
   .hello-greeting {
     float: left;
   }

--- a/src/sass/_profile.scss
+++ b/src/sass/_profile.scss
@@ -577,16 +577,16 @@ $padding-no-border: $total-padding - $border;
 .portfolio-top-nav-container {
   border-bottom: 1px solid $color-black;
   margin-bottom: 30px;
+}
 
-  .is-underlined {
-    border-bottom: 8px solid $color-black;
-    border-spacing: 6px;
-  }
+.is-underlined {
+  border-bottom: 8px solid $color-black;
+  border-spacing: 6px;
+}
 
-  .is-not-underlined {
-    border-bottom: 8px solid transparent;
-    border-spacing: 6px;
-  }
+.is-not-underlined {
+  border-bottom: 8px solid transparent;
+  border-spacing: 6px;
 }
 
 .portfolio-total-results {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -167,6 +167,24 @@ export const scrollToTop = (config = {}) => {
   scroll.scrollToTop({ ...defaultScrollConfig, ...config });
 };
 
+export const scrollToId = ({ el, config = {} }) => {
+  // Get an element's distance from the top of the page
+  const getElemDistance = (elem) => {
+    let location = 0;
+    if (elem.offsetParent) {
+      do {
+        location += elem.offsetTop;
+        elem = elem.offsetParent; // eslint-disable-line
+      } while (elem);
+    }
+    return location >= 0 ? location : 0;
+  };
+  const elem = document.querySelector(el);
+  const location = getElemDistance(elem);
+
+  scrollTo(location, config);
+};
+
 // When we want to grab a label, but aren't sure which one exists.
 // We set custom ones first in the list.
 export const getItemLabel = itemData =>
@@ -546,4 +564,20 @@ export const getScrollDistanceFromBottom = () => {
   const windowSize = window.innerHeight;
   const bodyHeight = document.body.offsetHeight;
   return (Math.max(bodyHeight - (scrollPosition + windowSize), 0));
+};
+
+// eslint-disable-next-line no-confusing-arrow
+export const getFormattedNumCSV = (v) => {
+  if (v === null || v === undefined) {
+    return '';
+  }
+  // else
+  return !isNaN(v) ? `=${v}` : v;
+};
+
+export const spliceStringForCSV = (v) => {
+  if (v[1] === '=') {
+    return `=${v.slice(0, 1)}${v.slice(2)}`;
+  }
+  return v;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8550,11 +8550,6 @@ react-autowhatever@^10.1.0:
     react-themeable "^1.1.0"
     section-iterator "^2.0.0"
 
-react-csv@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-1.1.1.tgz#718dadd2607a1795bfc8dbd32ca282a043739634"
-  integrity sha512-eQSrkEfzPN+1IeXT58kJaDNmpFr3RhdjfE09jTrw+jdTEp0g0Ig9NOI+TpvMBbCukE1HQhOf4dyrLDRFKgZzbA==
-
 react-dev-utils@^3.1.0, react-dev-utils@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-3.1.1.tgz#09ae7209a81384248db56547e718e65bd3b20eb5"


### PR DESCRIPTION
* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* feature: add bid list button to the favorites cards. TM-512

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Update empty saved search list text (#101)

* Add custom filter for including null language positions (#104)

* Remove Status component throughout app (#105)

* fix: change label. TM-632 (#107)

* Adjust elements to grow

* fix: allow export on edge to run

* Styles, add post to top

* Update ordering for data points on Compare page (#110)

* Remove post, add grade to bottom section

* Updates to Bid Tracker (#115)

* Add opacity to on-hold bids

* "priority" -> "pending"

* Prop to hide the delete button for standby bids

* Track favoriting loading state of individual IDs (#108)

* Track favoriting loading state of individual IDs

* Fix proptypes

* Handshake ribbon (#113)

* Re-usable Ribbon component, use Ribbon component to display if handshake has been offered on position

* Display handshake in condensed card, tests and snapshots

* Test coverage (#117)

* Test coverage for AccountDropdown, CompareDrawer, Compare

* Add tests for SetType

* Add toast notifications for favoriting actions (#114)

* Create BoxShadow component and use with various cards (#106)

* dev -> staging (#98) (#119)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Sprint 6 merge conflicts (#120)

* dev -> staging (#98)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Remove duplicates

* Add toggle component, use static toggle filter in search results (#121)

* Add condensed card layouts for projected vacancy and recently available (#122)

* dev -> staging (#98) (#127)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Move "No Language" filter to top of list (#129)

* Projected Vacancy - Saved Search + Results cards (#123)

* Projected vacancy in Saved Searches

* PV in results cards

* Fix typo, increase font size

* Increase filter container width, increase toggle font-size

* Refactor section headers in profile, static UI for projected vacancy notifications for favorites and bid list (#126)

* Pull css-box-shadow repo into app to force es6 to compile

* Chore/autodeploy config (#132)

* chore: update deploy config

* chore: update deploy config

* chore: update deploy config

* chore: update deploy config

* chore: update deploy config

* chore: update deploy config

* chore: use dev branch

* fix: update deploy script

* Compare from Favorites (#124)

* Add condensed card layouts for projected vacancy and recently available

* Add comparison buttons and comparison drawer to Favorites page

* Condensed Bid Tracker (#128)

* Alternate styles for condensed bid tracker, check for condensedView with Context API

* Additional styles/conditional rendering, scroll to bid on Bid Tracker with route id, snapshots

* Show Closed alert, style tweaks

* Style tweak to hide overlay alert for prepanel state

* Feature flags (#130)

* Feature flag implementation

* Feature flags for API

* fix: check for and remove if present the backup dir (#136)

* Remove jQuery and replace with XHR (#137)

* Different text and colors for Approved bids (#139)

* Hide Featured Positions section if positions length is zero (#138)

* Hide Featured Positions section if positions length is zero

* Update snapshot

* Set config.json to preferred defaults in dev environment

* Update index.html to reference API URL from config

* Update deploy.sh to use alternate config

* fix: include the bid count in the sections toggled by the bidding flag

* Add the Beta banner back in

* Use defaultSort prop instead of entire object; refresh state value on componentWillReceiveProps() (#148)

* New card design for Bidder Portfolio (#140)

* New card design for Bidder Portfolio, including badges (static for now)

* Fallback for no grade

* Update name format

* Make disabled badge color accessible

* Use aria-label to describe the meaning of the icon (#149)

* New row design for Bidder Portfolio (#141)

* New card design for Bidder Portfolio, including badges (static for now)

* Fallback for no grade

* New UI for Bidder Portfolio row view

* Update name format

* Add Export button to Bidder Portfolio (#142)

* Add auto-complete dropdown to display CDO list in Bidder Portfolio (#150)

* Increase test coverage (#151)

* Remove ABOUT_URL (#152)

* Update Jest (#153)

* Update Jest

* Update coverageReporters

* Bidder Portfolio Edit View (#144)

* New card design for Bidder Portfolio, including badges (static for now)

* Fallback for no grade

* New UI for Bidder Portfolio row view

* Update name format

* Add Export button to Bidder Portfolio

* Add Edit view for Bidder Portfolio rows

* UI For Bid Portfolio Edit View

* Public Profile "Updates" and Edit UI (#147)

* New card design for Bidder Portfolio, including badges (static for now)

* Fallback for no grade

* New UI for Bidder Portfolio row view

* Update name format

* Add Export button to Bidder Portfolio

* Add Edit view for Bidder Portfolio rows

* UI For Bid Portfolio Edit View

* Add "Updates" section, static edit UI to Public Profile

* Use react-picky to create a multi-select checkbox dropdown to use as a static UI Bid Cycle filter

* Improved test coverage

* Additional tests for SearchResultsExportLink and utilities

* More test coverage (#156)

* More test coverage

* Add test coverage to ListItem

* Add active filter (#158)

* staging -> sprint-8 (#160)

* Set min-width on compare drawer cards in IE11 (#161)

* Redirect standard error, for when file does not exist in CI (#162)

* Use common Export Button component for re-use (#163)

* Handle for when current_assignment is null (#165)

* "Service need" -> "Featured positions" sort name (#167)

* dev -> staging (#166) (#168)

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* feature: add bid list button to the favorites cards. TM-512

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Update empty saved search list text (#101)

* Add custom filter for including null language positions (#104)

* Remove Status component throughout app (#105)

* fix: change label. TM-632 (#107)

* Adjust elements to grow

* fix: allow export on edge to run

* Styles, add post to top

* Update ordering for data points on Compare page (#110)

* Remove post, add grade to bottom section

* Updates to Bid Tracker (#115)

* Add opacity to on-hold bids

* "priority" -> "pending"

* Prop to hide the delete button for standby bids

* Track favoriting loading state of individual IDs (#108)

* Track favoriting loading state of individual IDs

* Fix proptypes

* Handshake ribbon (#113)

* Re-usable Ribbon component, use Ribbon component to display if handshake has been offered on position

* Display handshake in condensed card, tests and snapshots

* Test coverage (#117)

* Test coverage for AccountDropdown, CompareDrawer, Compare

* Add tests for SetType

* Add toast notifications for favoriting actions (#114)

* Create BoxShadow component and use with various cards (#106)

* dev -> staging (#98) (#119)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Use react-linkify to automatically hyperlink URLs and email addresses in position capsule descriptions

* Authorization -> Authentication (#54)

* Authorization -> Authentication

* Rename import

* Update pagination and page size defaults in alignment with designs

* Display link, if available, in the glossary

* Add ability to edit links from Glossary editor; update styling for glossary links

* Reduce code complexity, fix long link styles

* Update snapshot

* Add bundlesize (#69)

* Add bundlsize and command

* Refine glob

* Refine maxSize target

* Chore/linter (#67)

* chore: fix linter is scss file

* fix: linter issue

* End of basic auth (#63)

* Delete login form

* Update actions

* Clean up sagas

* Remove isSAML checks

* Refactor sagas, CodeClimate fixes

* CodeClimate linting

* Upate login screen

* Simplify index

* Change to force external login

* get new custom auth working

* remove rest of the basic auth refs from server

* use env vars for env specific paths

* Bidder role - TM-371 (#68)

* Create permissions wrapper and conditionally render content based on bidder role

* remove default fallback prop

* Fix/mock auth (#70)

* fix: override some routes for the webpack dev server so auth works for local development

* fix: fix the conf so we can use the login.html when running the server in prod mode

* Default to true if can_delete property is not found

* Update snapshots

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* TM-410 - display favorites list as 4 across above the large break point (#66)

* fix: display favorites list as 4 across above the large break point

* fix: display favorites list as 4 across above the large break point

* fix: remove the auth redirect loop (#73)

* fix: remove the auth redirect loop and clean up reamining references to the LOGIN_MODE

* no conditional about url

* dev -> staging (#56) (#75)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix: add logo to saved search title

* fix: search page updates from qa

* chore: linter fix

* chore: fix linter issue

* fix: search page updates from qa

* chore: linter fix

* Remove feedback button site-wide

* Use object in state instead of array

* Minor edits to Homepage based on QA

* fix: make the pagination link clickable area larger

* fix: use the correct button style

* fix: better accessibility for active pagination tab selection

* fix: use correct button design

* fix: use lodash get so that non-existent nested property doesn't throw error  (#45)

* Use lodash get so that non-existent nested property doesn't throw error

* Check for details.id so that components don't render with an empty object

* Align bid count with data points in ResultsCondensedCard

* Show "Available" filter to all users, not just CDOs (#46)

* Update dashboard styles and content based on QA

* Fix style for bid list container

* Move Bid Count in-line with data points on ResultsCard

* View More -> View more

* Add disabled state for BidListButton based on proposed API updates

* Use real properties from API PR, combine strings

* Use white for button text color

* feature: add remove bid to the bid tracker for draft and submitted bids

* add additional status to the canDeleteBid function

* Add react-toastify and use with bid list additions/removals (#51)

* Add react-toastify and use with bid list additions/removals

* More tests for toast-related functionality

* Check if bid can be deleted and apply disabled status accordingly; update and optimize utility function

* feature: use the can_delete property from the bid rather than calculate client side

* Add loading spinner to Bid List button (#52)

* Compress us-flag.jpg (#53)

* Remove use of skill cone/code to skill (#76)

* Add Public Profile page - links from CDO portfolio, profile/public/:id route, add Assignments section to public profile, re-use of Profile Dashboard (#71)

## Relies on https://github.com/MetaPhase-Consulting/State-TalentMAP-API/pull/24

* Sort bid cycles alphabetically by name (#78)

* feature: download search results in csv format. Resolves TM-439

* chore: use default variable for sort

* chore: reformat the date before file creation

* Simplified search bar v2 (#81)

*  Make use of the existing simple search bar throughout site

* Offsets for homepage

* Redesign compare page (#82)

* Redesign compare page

* Remove old table styles; handle zero comparisons with route to catch it

* feature: move the download button and use the secondary style. resolves TM-511

* fix: set a width on the cards for the favorite positions profile screen (#80)

* fix: set a width on the cards for the favorite positions profile screen. resolves TM-410

* fix: no responsiveness for bid count and favorite buttons on position card displays

* feature: fixed width for all position cards (homepage, favorites, similar positions). Resolves TM-510

* fix: remove unnecessary class and fix padding on grid for correct wrapping

* chore: fixing the wrapping for the larger width

* Fix search styles from breaking on the bidder portfolio

* Reverting the changes to the glossary card due to the new term dialog breaking

* Add link-container class back in

* Update snapshots

* Trigger circleci build

* Code smells (#86)

* Update CodeClimate exclusions for local dev

* Reduce complexity

* Comparison drawer component, add event listeners where needed, remove old comparison UI from results page

* Track old compare choices to maintain sorting during an update

* Add test coverage, use cancel tokens

* Change dropdown menu link name from "Profile" to "Dashboard"

* Remove How to Bid section from position details (#89)

* Homepage QA (#90)

* Remove Inbox icon

* Fetch notifications from any screen, since we no longer use a /login route

* Remove the BetaHeader

* Conditional rendering of Bid Count on Bid Tracker cards, update Results cards data order and style

* Break out compare elements into their own rows, add Bid List button to comparisons, use Set() for bidListToggleIsLoading

* Remove eslint-disable

* feature: include org info for domestic positions (#92)

* Remove bidListToggleIsLoading since that is handled in BidListButton container

* Display the service needs filter as a pill on the results page (#95)

* Add error handling for position details screen (#93)

* Add error handling for position details screen

* Update call to action

* Update based on design feedback

* dev -> staging

* Make icons consistent throughout profile pages (#102)

* Service Needs -> Featured (#100)

* Add hover to dropdown (#103)

* Sprint 6 merge conflicts (#120)

* dev -> staging (#98)

* chore: remove unnecessary css file from the build output

* chore: update docs regarding apache compression config

* Update bid list due date to match site-wide format

* Use position id instead of position_number to query for position details

* chore: remove unused props from components

* chore: fix err due to incorrect favicon size in manifest

* chore: remove unused props from the Home container

* chore: remove unused props from the HomePagePositionsContainer component

* fix: update profile page based on qa

* Update styles and content in Position Details page based on QA feedback

* fix…